### PR TITLE
Feature/게임 룸 관련 이벤트 로직 개선

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
@@ -49,11 +49,7 @@ public class GameRoom extends BaseEntity {
     }
 
     public static GameRoom createGameRoomByHost(User host) {
-        GameRoom gameRoom = new GameRoom(host, "겁나 쩌는 게임", 10, 3);
-        UserGameRoom userGameRoom = new UserGameRoom(gameRoom, host);
-
-        gameRoom.userGameRooms.add(userGameRoom);
-        return gameRoom;
+        return new GameRoom(host, "겁나 쩌는 게임", 10, 3);
     }
 
     public boolean canStartGame() {

--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
@@ -71,8 +71,16 @@ public class GameRoom extends BaseEntity {
         }
     }
 
-    public boolean canJoinGameRoom() {
-        return this.getUserGameRooms().size() < this.getSetting().getMaxPlayers();
+    public void checkJoinGameRoom(User user) {
+        if (userGameRooms.size() >= setting.getMaxPlayers()) {
+            throw new BusinessException(GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER);
+        }
+        if (this.status != GameRoomStatus.READY) {
+            throw new BusinessException(GameRoomErrorCode.CANNOT_JOIN_PLAYING_GAME_ROOM);
+        }
+        if (this.getPlayers().stream().anyMatch(player -> player.getId().equals(user.getId()))) {
+            throw new BusinessException(GameRoomErrorCode.ALREADY_JOINED_GAME_ROOM);
+        }
     }
 
     public void startGame() {

--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
@@ -5,6 +5,8 @@ import com.goldstone.saboteur_backend.domain.enums.GameRoomStatus;
 import com.goldstone.saboteur_backend.domain.mapping.UserGameRole;
 import com.goldstone.saboteur_backend.domain.mapping.UserGameRoom;
 import com.goldstone.saboteur_backend.domain.user.User;
+import com.goldstone.saboteur_backend.exception.BusinessException;
+import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,12 +54,21 @@ public class GameRoom extends BaseEntity {
         return new GameRoom(host, "겁나 쩌는 게임", 10, 3);
     }
 
-    public boolean canStartGame() {
+    public void canStartGame(UUID userId) {
         Integer playerCount = this.userGameRooms.size();
         Integer minPlayers = this.setting.getMinPlayers();
         Integer maxPlayers = this.setting.getMaxPlayers();
+        boolean validPlayerCount = minPlayers <= playerCount && playerCount <= maxPlayers;
+        if (!validPlayerCount) {
+            throw new BusinessException(GameRoomErrorCode.CANNOT_START_GAME);
+        }
 
-        return minPlayers <= playerCount && playerCount <= maxPlayers;
+        boolean matchHost = this.setting.getHost().getId().equals(userId);
+        boolean joinedHost =
+                this.getPlayers().stream().anyMatch(player -> player.getId().equals(userId));
+        if (!matchHost || !joinedHost) {
+            throw new BusinessException(GameRoomErrorCode.CANNOT_START_GAME_NOT_HOST);
+        }
     }
 
     public boolean canJoinGameRoom() {

--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameRoom.java
@@ -65,12 +65,12 @@ public class GameRoom extends BaseEntity {
     }
 
     public void startGame() {
-        this.status = GameRoomStatus.PLAYING;
+        this.changeStatus(GameRoomStatus.PLAYING);
     }
 
     /** NOTE: Game이 종료되면 id + 1인 같은 속성을 가진 새로운 게임 객체를 생성하고, 그 객체에서 게임을 진행할 수 있도록 한다. */
     public void endGame() {
-        this.status = GameRoomStatus.END;
+        this.changeStatus(GameRoomStatus.END);
         // 필요에 따라 추가 로직 필요.
     }
 

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/request/StartGameRequestDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/request/StartGameRequestDto.java
@@ -9,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class StartGameRequestDto {
+    private UUID userId;
     private UUID gameRoomId;
 }

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/GameRoomInfoResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/GameRoomInfoResponseDto.java
@@ -1,0 +1,31 @@
+package com.goldstone.saboteur_backend.dtos.gameRoom.response;
+
+import com.goldstone.saboteur_backend.domain.enums.GameRoomStatus;
+import com.goldstone.saboteur_backend.domain.game.GameRoom;
+import com.goldstone.saboteur_backend.dtos.gameSetting.response.GameSettingInfoResponseDto;
+import com.goldstone.saboteur_backend.dtos.user.response.UserInfoResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GameRoomInfoResponseDto {
+    private final String id;
+    private final GameRoomStatus status;
+    private final Integer round;
+    private final GameSettingInfoResponseDto setting;
+    private final UserInfoResponseDto[] players;
+
+    public static GameRoomInfoResponseDto from(GameRoom gameRoom) {
+        return GameRoomInfoResponseDto.builder()
+                .id(gameRoom.getId().toString())
+                .status(gameRoom.getStatus())
+                .round(gameRoom.getRound())
+                .setting(GameSettingInfoResponseDto.from(gameRoom.getSetting()))
+                .players(
+                        gameRoom.getPlayers().stream()
+                                .map(UserInfoResponseDto::from)
+                                .toArray(UserInfoResponseDto[]::new))
+                .build();
+    }
+}

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/JoinGameRoomResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/JoinGameRoomResponseDto.java
@@ -1,8 +1,25 @@
 package com.goldstone.saboteur_backend.dtos.gameRoom.response;
 
+import com.goldstone.saboteur_backend.domain.game.GameRoom;
+import com.goldstone.saboteur_backend.dtos.user.response.UserInfoResponseDto;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public class JoinGameRoomResponseDto {}
+public class JoinGameRoomResponseDto {
+    private String gameRoomId;
+    private int currentPlayerCount;
+    private UserInfoResponseDto[] players;
+
+    public static JoinGameRoomResponseDto from(GameRoom gameRoom) {
+        return JoinGameRoomResponseDto.builder()
+                .gameRoomId(gameRoom.getId().toString())
+                .currentPlayerCount(gameRoom.getPlayers().size())
+                .players(
+                        gameRoom.getPlayers().stream()
+                                .map(UserInfoResponseDto::from)
+                                .toArray(UserInfoResponseDto[]::new))
+                .build();
+    }
+}

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameSetting/response/GameSettingInfoResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameSetting/response/GameSettingInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.goldstone.saboteur_backend.dtos.gameSetting.response;
+
+import com.goldstone.saboteur_backend.domain.game.GameSetting;
+import com.goldstone.saboteur_backend.dtos.user.response.UserInfoResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GameSettingInfoResponseDto {
+    private final UserInfoResponseDto host;
+    private final String title;
+    private final Integer maxPlayers;
+    private final Integer minPlayers;
+
+    public static GameSettingInfoResponseDto from(GameSetting gameSetting) {
+        return GameSettingInfoResponseDto.builder()
+                .host(UserInfoResponseDto.from(gameSetting.getHost()))
+                .title(gameSetting.getTitle())
+                .maxPlayers(gameSetting.getMaxPlayers())
+                .minPlayers(gameSetting.getMinPlayers())
+                .build();
+    }
+}

--- a/src/main/java/com/goldstone/saboteur_backend/exception/code/error/CommonErrorCode.java
+++ b/src/main/java/com/goldstone/saboteur_backend/exception/code/error/CommonErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "E001", "잘못된 요청입니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "E002", "입력값이 올바르지 않습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E001", "서버 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E001", "서버 오류입니다."),
+    FAILED_TO_MANIPULATE_GLOBAL_SESSION(
+            HttpStatus.INTERNAL_SERVER_ERROR, "E002", "글로벌 세션 조작에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
+++ b/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
@@ -10,7 +10,8 @@ public enum GameRoomErrorCode implements ErrorCode {
     GAME_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "G001", "게임 룸을 찾을 수 없습니다."),
     CANNOT_JOIN_MAX_PLAYER(HttpStatus.BAD_REQUEST, "G002", "최대 인원 수가 초과되어 게임 룸에 입장할 수 없습니다."),
     CANNOT_START_GAME(HttpStatus.BAD_REQUEST, "G003", "게임을 시작할 수 없습니다."),
-    ALREADY_JOINED_GAME_ROOM(HttpStatus.BAD_REQUEST, "G004", "이미 게임 룸에 입장한 플레이어입니다.");
+    ALREADY_JOINED_GAME_ROOM(HttpStatus.BAD_REQUEST, "G004", "이미 게임 룸에 입장한 플레이어입니다."),
+    CANNOT_START_GAME_NOT_HOST(HttpStatus.UNAUTHORIZED, "G005", "호스트만 게임을 시작할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
+++ b/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
@@ -11,7 +11,8 @@ public enum GameRoomErrorCode implements ErrorCode {
     CANNOT_JOIN_MAX_PLAYER(HttpStatus.BAD_REQUEST, "G002", "최대 인원 수가 초과되어 게임 룸에 입장할 수 없습니다."),
     CANNOT_START_GAME(HttpStatus.BAD_REQUEST, "G003", "게임을 시작할 수 없습니다."),
     ALREADY_JOINED_GAME_ROOM(HttpStatus.BAD_REQUEST, "G004", "이미 게임 룸에 입장한 플레이어입니다."),
-    CANNOT_START_GAME_NOT_HOST(HttpStatus.UNAUTHORIZED, "G005", "호스트만 게임을 시작할 수 있습니다.");
+    CANNOT_START_GAME_NOT_HOST(HttpStatus.UNAUTHORIZED, "G005", "호스트만 게임을 시작할 수 있습니다."),
+    CANNOT_JOIN_PLAYING_GAME_ROOM(HttpStatus.BAD_REQUEST, "G006", "게임이 진행 중인 게임 룸에는 입장할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
+++ b/src/main/java/com/goldstone/saboteur_backend/exception/code/error/GameRoomErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum GameRoomErrorCode implements ErrorCode {
     GAME_ROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "G001", "게임 룸을 찾을 수 없습니다."),
     CANNOT_JOIN_MAX_PLAYER(HttpStatus.BAD_REQUEST, "G002", "최대 인원 수가 초과되어 게임 룸에 입장할 수 없습니다."),
-    CANNOT_START_GAME(HttpStatus.BAD_REQUEST, "G003", "게임을 시작할 수 없습니다.");
+    CANNOT_START_GAME(HttpStatus.BAD_REQUEST, "G003", "게임을 시작할 수 없습니다."),
+    ALREADY_JOINED_GAME_ROOM(HttpStatus.BAD_REQUEST, "G004", "이미 게임 룸에 입장한 플레이어입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/goldstone/saboteur_backend/exception/responseDto/ErrorResponse.java
+++ b/src/main/java/com/goldstone/saboteur_backend/exception/responseDto/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.goldstone.saboteur_backend.exception.responseDto;
 
+import com.goldstone.saboteur_backend.exception.code.error.CommonErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.ErrorCode;
 import java.util.List;
 import lombok.Getter;
@@ -27,5 +28,9 @@ public class ErrorResponse {
         this.code = code;
         this.message = message;
         this.errors = errors;
+    }
+
+    public static ErrorResponse internalServerError() {
+        return new ErrorResponse(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
@@ -7,9 +7,9 @@ import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestD
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
 
 public interface GameRoomService {
-    GameRoom createGameRoom(CreateGameRoomRequestDto dto) throws Exception;
+    GameRoom createGameRoom(CreateGameRoomRequestDto dto);
 
-    void joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto) throws Exception;
+    GameRoom joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto);
 
     void startGame(StartGameRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
@@ -11,5 +11,5 @@ public interface GameRoomService {
 
     GameRoom joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto);
 
-    void startGame(StartGameRequestDto dto) throws Exception;
+    GameRoom startGame(StartGameRequestDto dto);
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -11,6 +11,7 @@ import com.goldstone.saboteur_backend.domain.user.UserCardDeck;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.CreateGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
+import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.UserErrorCode;
 import com.goldstone.saboteur_backend.session.GlobalSession;
@@ -29,10 +30,10 @@ public class GameRoomServiceImpl implements GameRoomService {
     private final SocketIoService socketIoService;
 
     @Override
-    public GameRoom createGameRoom(CreateGameRoomRequestDto dto) throws Exception {
+    public GameRoom createGameRoom(CreateGameRoomRequestDto dto) {
         User host = this.globalSession.getUserSession(dto.getUserId());
         if (host == null) {
-            throw new Exception(UserErrorCode.USER_NOT_FOUND.getMessage());
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
         }
 
         GameRoom gameRoom = GameRoom.createGameRoomByHost(host);
@@ -47,29 +48,28 @@ public class GameRoomServiceImpl implements GameRoomService {
     }
 
     @Override
-    public void joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto) throws Exception {
-        try {
-            User user = this.globalSession.getUserSession(dto.getUserId());
-            if (user == null) {
-                throw new Exception(UserErrorCode.USER_NOT_FOUND.getMessage());
-            }
-
-            GameRoom gameRoom = this.globalSession.getGameRoomSession(dto.getGameRoomId());
-            if (gameRoom == null) {
-                throw new Exception(GameRoomErrorCode.GAME_ROOM_NOT_FOUND.getMessage());
-            }
-            if (!gameRoom.canJoinGameRoom()) {
-                throw new Exception(GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER.getMessage());
-            }
-
-            gameRoom.addPlayer(user);
-
-            client.joinRoom(gameRoom.getId().toString());
-            client.sendEvent("gameRoomJoined");
-        } catch (Exception e) {
-            client.sendEvent("error", e.getMessage());
-            throw e;
+    public GameRoom joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto) {
+        User user = this.globalSession.getUserSession(dto.getUserId());
+        if (user == null) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
         }
+
+        GameRoom gameRoom = this.globalSession.getGameRoomSession(dto.getGameRoomId());
+        if (gameRoom == null) {
+            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
+        }
+        if (!gameRoom.canJoinGameRoom()) {
+            throw new BusinessException(GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER);
+        }
+        if (gameRoom.getPlayers().stream()
+                .anyMatch(player -> player.getId().equals(user.getId()))) {
+            throw new BusinessException(GameRoomErrorCode.ALREADY_JOINED_GAME_ROOM);
+        }
+
+        gameRoom.addPlayer(user);
+        client.joinRoom(gameRoom.getId().toString());
+
+        return gameRoom;
     }
 
     public void startGame(StartGameRequestDto dto) throws Exception {

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -68,18 +68,21 @@ public class GameRoomServiceImpl implements GameRoomService {
         return gameRoom;
     }
 
-    public void startGame(StartGameRequestDto dto) throws Exception {
+    public GameRoom startGame(StartGameRequestDto dto) {
         GameRoom gameRoom = this.globalSession.getGameRoomSession(dto.getGameRoomId());
         if (gameRoom == null) {
-            throw new Exception(GameRoomErrorCode.GAME_ROOM_NOT_FOUND.getMessage());
+            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
         }
         if (!gameRoom.canStartGame()) {
-            throw new Exception(GameRoomErrorCode.CANNOT_START_GAME.getMessage());
+            throw new BusinessException(GameRoomErrorCode.CANNOT_START_GAME);
         }
 
         gameRoom.startGame();
+
+        // 보드 생성
         this.globalSession.addGameBoardSession(gameRoom, new Board());
 
+        // 턴 매니저 생성
         GameTurnManager turnManager = new GameTurnManager(gameRoom.getUserGameRooms());
         this.globalSession.addTurnManagerSession(gameRoom.getId(), turnManager);
 
@@ -87,18 +90,16 @@ public class GameRoomServiceImpl implements GameRoomService {
         GameCardPool cardPool = GameCardPool.createDefaultPool(gameRoom.getId());
         this.globalSession.addGameCardPoolSession(gameRoom.getId(), cardPool);
 
-        // 카드 분배 로직
-        List<UserGameRoom> userGameRooms = gameRoom.getUserGameRooms();
-
         // 카드 분배
+        List<UserGameRoom> userGameRooms = gameRoom.getUserGameRooms();
+        int cardPerPlayer = GameCardPool.getCardsPerPlayer(userGameRooms.size());
         Map<User, UserCardDeck> userCardDecks =
-                cardPool.assignCardsToUserDecks(
-                        userGameRooms, GameCardPool.getCardsPerPlayer(userGameRooms.size()));
+                cardPool.assignCardsToUserDecks(userGameRooms, cardPerPlayer);
 
         for (User user : userCardDecks.keySet()) {
             user.setCardDeck(userCardDecks.get(user));
         }
 
-        this.socketIoService.sendBroadCast(gameRoom.getId(), "gameStarted", "Hello, game started!");
+        return gameRoom;
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -73,10 +73,7 @@ public class GameRoomServiceImpl implements GameRoomService {
         if (gameRoom == null) {
             throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
         }
-        if (!gameRoom.canStartGame()) {
-            throw new BusinessException(GameRoomErrorCode.CANNOT_START_GAME);
-        }
-
+        gameRoom.canStartGame(dto.getUserId());
         gameRoom.startGame();
 
         // 보드 생성

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -54,13 +54,8 @@ public class GameRoomServiceImpl implements GameRoomService {
         if (gameRoom == null) {
             throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
         }
-        if (!gameRoom.canJoinGameRoom()) {
-            throw new BusinessException(GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER);
-        }
-        if (gameRoom.getPlayers().stream()
-                .anyMatch(player -> player.getId().equals(user.getId()))) {
-            throw new BusinessException(GameRoomErrorCode.ALREADY_JOINED_GAME_ROOM);
-        }
+
+        gameRoom.checkJoinGameRoom(user);
 
         gameRoom.addPlayer(user);
         client.joinRoom(gameRoom.getId().toString());

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -40,10 +40,6 @@ public class GameRoomServiceImpl implements GameRoomService {
 
         this.globalSession.addGameRoomSession(gameRoom);
 
-        // 카드풀 생성 및 UUID 할당
-        GameCardPool cardPool = GameCardPool.createDefaultPool(gameRoom.getId());
-        this.globalSession.addGameCardPoolSession(gameRoom.getId(), cardPool);
-
         return gameRoom;
     }
 
@@ -87,8 +83,11 @@ public class GameRoomServiceImpl implements GameRoomService {
         GameTurnManager turnManager = new GameTurnManager(gameRoom.getUserGameRooms());
         this.globalSession.addTurnManagerSession(gameRoom.getId(), turnManager);
 
+        // 카드풀 생성 및 UUID 할당
+        GameCardPool cardPool = GameCardPool.createDefaultPool(gameRoom.getId());
+        this.globalSession.addGameCardPoolSession(gameRoom.getId(), cardPool);
+
         // 카드 분배 로직
-        GameCardPool cardPool = this.globalSession.getGameCardPoolSession(dto.getGameRoomId());
         List<UserGameRoom> userGameRooms = gameRoom.getUserGameRooms();
 
         // 카드 분배

--- a/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
+++ b/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
@@ -5,6 +5,8 @@ import com.goldstone.saboteur_backend.domain.game.GameCardPool;
 import com.goldstone.saboteur_backend.domain.game.GameRoom;
 import com.goldstone.saboteur_backend.domain.game.GameTurnManager;
 import com.goldstone.saboteur_backend.domain.user.User;
+import com.goldstone.saboteur_backend.exception.BusinessException;
+import com.goldstone.saboteur_backend.exception.code.error.CommonErrorCode;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,8 +30,8 @@ public class GlobalSession {
         try {
             return action.get();
         } catch (Exception e) {
-            System.err.println("Exception in wrapperCall: " + e.getMessage());
-            return null;
+            System.err.println("Exception in GlobalSession wrapperCall:\n" + e);
+            throw new BusinessException(CommonErrorCode.FAILED_TO_MANIPULATE_GLOBAL_SESSION);
         }
     }
 

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
@@ -1,8 +1,13 @@
 package com.goldstone.saboteur_backend.socketIo.eventRegister;
 
 import com.corundumstudio.socketio.SocketIOServer;
+import com.goldstone.saboteur_backend.domain.game.GameRoom;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
+import com.goldstone.saboteur_backend.dtos.gameRoom.response.JoinGameRoomResponseDto;
+import com.goldstone.saboteur_backend.exception.BusinessException;
+import com.goldstone.saboteur_backend.exception.code.error.ErrorCode;
+import com.goldstone.saboteur_backend.exception.responseDto.ErrorResponse;
 import com.goldstone.saboteur_backend.service.gameRoom.GameRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,7 +22,20 @@ public class GameRoomEventRegister implements SocketEventRegister {
         server.addEventListener(
                 "joinGameRoom",
                 JoinGameRoomRequestDto.class,
-                (client, data, ackSender) -> this.gameRoomService.joinGameRoom(client, data));
+                (client, data, ackSender) -> {
+                    try {
+                        GameRoom gameRoom = this.gameRoomService.joinGameRoom(client, data);
+
+                        client.sendEvent("gameRoomJoined", JoinGameRoomResponseDto.from(gameRoom));
+                    } catch (Exception e) {
+                        if (e instanceof BusinessException) {
+                            ErrorCode errorCode = ((BusinessException) e).getErrorCode();
+                            client.sendEvent("errorEvent", new ErrorResponse(errorCode));
+                        } else {
+                            client.sendEvent("errorEvent", ErrorResponse.internalServerError());
+                        }
+                    }
+                });
         server.addEventListener(
                 "startGame",
                 StartGameRequestDto.class,

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
@@ -4,11 +4,13 @@ import com.corundumstudio.socketio.SocketIOServer;
 import com.goldstone.saboteur_backend.domain.game.GameRoom;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
+import com.goldstone.saboteur_backend.dtos.gameRoom.response.GameRoomInfoResponseDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.response.JoinGameRoomResponseDto;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.ErrorCode;
 import com.goldstone.saboteur_backend.exception.responseDto.ErrorResponse;
 import com.goldstone.saboteur_backend.service.gameRoom.GameRoomService;
+import com.goldstone.saboteur_backend.socketIo.SocketIoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class GameRoomEventRegister implements SocketEventRegister {
     private final GameRoomService gameRoomService;
+    private final SocketIoService socketIoService;
 
     @Override
     public void registerEvents(SocketIOServer server) {
@@ -39,6 +42,22 @@ public class GameRoomEventRegister implements SocketEventRegister {
         server.addEventListener(
                 "startGame",
                 StartGameRequestDto.class,
-                (client, data, ackSender) -> this.gameRoomService.startGame(data));
+                (client, data, ackSender) -> {
+                    try {
+                        GameRoom gameRoom = this.gameRoomService.startGame(data);
+
+                        this.socketIoService.sendBroadCast(
+                                gameRoom.getId(),
+                                "gameStarted",
+                                GameRoomInfoResponseDto.from(gameRoom));
+                    } catch (Exception e) {
+                        if (e instanceof BusinessException) {
+                            ErrorCode errorCode = ((BusinessException) e).getErrorCode();
+                            client.sendEvent("errorEvent", new ErrorResponse(errorCode));
+                        } else {
+                            client.sendEvent("errorEvent", ErrorResponse.internalServerError());
+                        }
+                    }
+                });
     }
 }

--- a/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.corundumstudio.socketio.SocketIOClient;
+import com.goldstone.saboteur_backend.domain.enums.GameRoomStatus;
 import com.goldstone.saboteur_backend.domain.game.GameRoom;
 import com.goldstone.saboteur_backend.domain.user.User;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.CreateGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
+import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
 import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import com.goldstone.saboteur_backend.session.GlobalSession;
 import java.time.LocalDate;
@@ -31,6 +33,18 @@ class GameRoomServiceTest {
     @BeforeEach
     void setUp() {
         this.globalSession.addUserSession(this.host);
+    }
+
+    private List<User> createUsers(int count) {
+        List<User> users = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            User user = new User("User" + i, LocalDate.now());
+            users.add(user);
+            this.globalSession.addUserSession(user);
+        }
+
+        return users;
     }
 
     @Test
@@ -68,12 +82,7 @@ class GameRoomServiceTest {
     @Test
     @DisplayName("게임 룸에 있는 유저 수가 10명을 초과한 상태에서 새로운 유저가 입장할 경우, 에러가 발생한다.")
     void joinGameRoomIfGameRoomPlayerOver10() throws Exception {
-        List<User> users = new ArrayList<>();
-        for (int i = 1; i <= 10; i++) {
-            User user = new User("User" + i, LocalDate.now());
-            users.add(user);
-            this.globalSession.addUserSession(user);
-        }
+        List<User> users = this.createUsers(10);
 
         GameRoom gameRoom =
                 this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
@@ -99,6 +108,78 @@ class GameRoomServiceTest {
                                         this.mockClient,
                                         new JoinGameRoomRequestDto(
                                                 users.get(9).getId(), gameRoom.getId())));
-        assertEquals(exception.getMessage(), GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER.getMessage());
+        assertEquals(GameRoomErrorCode.CANNOT_JOIN_MAX_PLAYER.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName(
+            "게임을 시작하는 조건이 충족되지 않았을 때 에러가 발생한다. 게임을 시작하는 주체는 호스트이고, 최소 인원 수를 만족했을 때만 게임 시작이 가능하다.")
+    void startGameIfGameStartConditionsFulfilled() {
+        GameRoom gameRoom =
+                this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
+        this.gameRoomService.joinGameRoom(
+                this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
+
+        Exception exception;
+
+        // 게임 시작을 위한 최소 인원 수를 맞추지 않았기 때문에 에러가 발생한다.
+        exception =
+                assertThrows(
+                        Exception.class,
+                        () ->
+                                this.gameRoomService.startGame(
+                                        new StartGameRequestDto(host.getId(), gameRoom.getId())));
+        assertEquals(GameRoomErrorCode.CANNOT_START_GAME.getMessage(), exception.getMessage());
+
+        // 이미 입장한 플레이어는 재입장이 불가능하다.
+        exception =
+                assertThrows(
+                        Exception.class,
+                        () ->
+                                this.gameRoomService.joinGameRoom(
+                                        this.mockClient,
+                                        new JoinGameRoomRequestDto(
+                                                host.getId(), gameRoom.getId())));
+        assertEquals(
+                GameRoomErrorCode.ALREADY_JOINED_GAME_ROOM.getMessage(), exception.getMessage());
+
+        // 9명의 유저까지 모두 입장 가능하다.
+        List<User> users = this.createUsers(4);
+        for (int i = 0; i < 3; i++) {
+            this.gameRoomService.joinGameRoom(
+                    this.mockClient,
+                    new JoinGameRoomRequestDto(users.get(i).getId(), gameRoom.getId()));
+        }
+        GameRoom gameRoomFromSession = this.globalSession.getGameRoomSession(gameRoom.getId());
+        assertEquals(4, gameRoomFromSession.getUserGameRooms().size());
+
+        // 최소 인원은 충족했지만, 호스트가 아닌 다른 플레이어는 게임을 시작할 수 없다.
+        exception =
+                assertThrows(
+                        Exception.class,
+                        () ->
+                                this.gameRoomService.startGame(
+                                        new StartGameRequestDto(
+                                                users.get(0).getId(), gameRoom.getId())));
+        assertEquals(
+                GameRoomErrorCode.CANNOT_START_GAME_NOT_HOST.getMessage(), exception.getMessage());
+
+        // 호스트가 게임을 시작할 수 있다.
+        assertEquals(GameRoomStatus.READY, gameRoom.getStatus());
+        this.gameRoomService.startGame(new StartGameRequestDto(host.getId(), gameRoom.getId()));
+        assertEquals(GameRoomStatus.PLAYING, gameRoom.getStatus());
+
+        // 게임이 시작된 후에는 더 이상 유저가 게임 룸에 입장할 수 없다.
+        exception =
+                assertThrows(
+                        Exception.class,
+                        () ->
+                                this.gameRoomService.joinGameRoom(
+                                        this.mockClient,
+                                        new JoinGameRoomRequestDto(
+                                                users.get(3).getId(), gameRoom.getId())));
+        assertEquals(
+                GameRoomErrorCode.CANNOT_JOIN_PLAYING_GAME_ROOM.getMessage(),
+                exception.getMessage());
     }
 }

--- a/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
@@ -54,6 +54,7 @@ class GameRoomServiceTest {
 
         GameRoom gameRoom =
                 this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
+        this.gameRoomService.joinGameRoom(this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
         this.globalSession.addGameRoomSession(gameRoom);
 
         this.gameRoomService.joinGameRoom(
@@ -75,6 +76,7 @@ class GameRoomServiceTest {
 
         GameRoom gameRoom =
                 this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
+        this.gameRoomService.joinGameRoom(this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
         this.globalSession.addGameRoomSession(gameRoom);
 
         // 9명의 유저까지 모두 입장 가능하다.

--- a/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceTest.java
@@ -54,7 +54,8 @@ class GameRoomServiceTest {
 
         GameRoom gameRoom =
                 this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
-        this.gameRoomService.joinGameRoom(this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
+        this.gameRoomService.joinGameRoom(
+                this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
         this.globalSession.addGameRoomSession(gameRoom);
 
         this.gameRoomService.joinGameRoom(
@@ -76,7 +77,8 @@ class GameRoomServiceTest {
 
         GameRoom gameRoom =
                 this.gameRoomService.createGameRoom(new CreateGameRoomRequestDto(host.getId()));
-        this.gameRoomService.joinGameRoom(this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
+        this.gameRoomService.joinGameRoom(
+                this.mockClient, new JoinGameRoomRequestDto(host.getId(), gameRoom.getId()));
         this.globalSession.addGameRoomSession(gameRoom);
 
         // 9명의 유저까지 모두 입장 가능하다.


### PR DESCRIPTION
커밋별로 확인하시면 편할듯 합니다.

## 게임 입장 이벤트 고도화
https://github.com/Software-Engineering-GoldStone/Backend/commit/3c495d8d51948bec24d05d3ce190ad94ce764be4

`joinGameRoom` 이벤트 호출 시, 올바른 응답을 할 수 있도록 구현하였습니다.

- 응답

```json
{
    "gameRoomId": "4337954c-3421-44ea-bb73-0ae3bc093c1d",
    "currentPlayerCount": 2,
    "players": [
        {
            "id": "abab5004-915c-4d12-87ab-0fa82ec574ac",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        },
        {
            "id": "4dc192b8-165a-4b76-a121-e14f64500584",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        }
    ]
}
```

---

## 카드풀 생성 로직 변경 및 호스트 입장 로직 삭제
https://github.com/Software-Engineering-GoldStone/Backend/commit/0c91ea2b472819e58ab788de7d71341a5bfd5c9d

- 게임 방을 만들때만 카드풀을 만들도록 되어있어, **게임을 시작할때 카드 풀을 만들도록 하였습니다.**
- 게임 방을 만들고 userGameRoom에 호스트가 입장했다고 되어 있는데, **소켓 룸에선 호스트가 입장하지 않는 버그가 있어 로직을 개선하였습니다.**

---

## 게임 시작 이벤트 고도화
https://github.com/Software-Engineering-GoldStone/Backend/commit/5e938adb42c67c760596a5e3aa1b3b99f0aa9104

게임을 시작할 때, 게임 룸에 대한 정보를 응답할 수 있도록 구현하였습니다.

- 응답

```json
{
    "id": "4337954c-3421-44ea-bb73-0ae3bc093c1d",
    "status": "PLAYING",
    "round": 1,
    "setting": {
        "host": {
            "id": "abab5004-915c-4d12-87ab-0fa82ec574ac",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        },
        "title": "겁나 쩌는 게임",
        "maxPlayers": 10,
        "minPlayers": 3
    },
    "players": [
        {
            "id": "abab5004-915c-4d12-87ab-0fa82ec574ac",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        },
        {
            "id": "4dc192b8-165a-4b76-a121-e14f64500584",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        },
        {
            "id": "8cc1569c-aa7c-4887-bb08-8415c7f58387",
            "nickname": "내가 방장이다",
            "birthDate": "2000-01-22"
        }
    ]
}
```

---

## 게임 시작 검증 로직 고도화
https://github.com/Software-Engineering-GoldStone/Backend/commit/20e762153de6c1a75ad1c1aa5010e5f53849b80e

**호스트만 시작을 할 수 있게, 그리고 호스트가 게임 룸에 접속해있는지** 검증하는 로직을 추가하였습니다.