### PR TITLE
GameCardPool의 PathCard(길카드) 수정

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameCardPool.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameCardPool.java
@@ -47,10 +47,25 @@ public class GameCardPool {
     public static GameCardPool createDefaultPool(UUID GameRoomId) {
         List<Card> cardList = new LinkedList<>();
 
-        // 길카드 (예시: CROSSROAD 44장, 실제로는 다양한 PathCardType을 추가해야 함)
-        for (int i = 0; i < 44; i++) {
-            cardList.add(new PathCard(PathCardType.CROSSROAD, false));
-        }
+        // DeadEnd 타입 (각 1장씩)
+        cardList.add(new PathCard(PathCardType.BOTH_HORIZONTAL_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.BOTH_VERTICAL_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.CROSSROAD_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.HORIZONTAL_T_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.VERTICAL_T_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.LEFT_TURN_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.RIGHT_TURN_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.SINGLE_HORIZONTAL_DEADEND, false));
+        cardList.add(new PathCard(PathCardType.SINGLE_VERTICAL_DEADEND, false));
+
+        // 일반 타입
+        for (int i = 0; i < 5; i++) cardList.add(new PathCard(PathCardType.CROSSROAD, false));
+        for (int i = 0; i < 3; i++) cardList.add(new PathCard(PathCardType.HORIZONTAL, false));
+        for (int i = 0; i < 5; i++) cardList.add(new PathCard(PathCardType.HORIZONTAL_T, false));
+        for (int i = 0; i < 4; i++) cardList.add(new PathCard(PathCardType.LEFT_TURN, false));
+        for (int i = 0; i < 4; i++) cardList.add(new PathCard(PathCardType.RIGHT_TURN, false));
+        for (int i = 0; i < 4; i++) cardList.add(new PathCard(PathCardType.VERTICAL, false));
+        for (int i = 0; i < 5; i++) cardList.add(new PathCard(PathCardType.VERTICAL_T, false));
 
         // 도구 파괴 (각 3장씩)
         for (int i = 0; i < 3; i++) cardList.add(new BreakToolCard(TargetToolType.PICKAX));
@@ -61,6 +76,7 @@ public class GameCardPool {
         for (int i = 0; i < 2; i++) cardList.add(new RepairToolCard(Set.of(TargetToolType.PICKAX)));
         for (int i = 0; i < 2; i++) cardList.add(new RepairToolCard(Set.of(TargetToolType.CART)));
         for (int i = 0; i < 2; i++) cardList.add(new RepairToolCard(Set.of(TargetToolType.LIGHT)));
+
         // 도구 수리 (2개 조합 각 1장씩)
         cardList.add(new RepairToolCard(Set.of(TargetToolType.PICKAX, TargetToolType.CART)));
         cardList.add(new RepairToolCard(Set.of(TargetToolType.PICKAX, TargetToolType.LIGHT)));
@@ -73,8 +89,8 @@ public class GameCardPool {
         for (int i = 0; i < 6; i++) cardList.add(new MapCard());
 
         Collections.shuffle(cardList);
-        // 총 71장 검증
-        if (cardList.size() != 71) {
+        // 총 66장 검증
+        if (cardList.size() != 66) {
             throw new IllegalStateException("카드풀이 71장으로 초기화되지 않았습니다.");
         }
 

--- a/src/test/java/com/goldstone/saboteur_backend/domain/GameCardPool/GameCardPoolTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/domain/GameCardPool/GameCardPoolTest.java
@@ -23,11 +23,11 @@ class GameCardPoolTest {
         List<Card> cards = new ArrayList<>(pool.getCards());
 
         // 전체 카드 수
-        assertThat(cards.size()).isEqualTo(71);
+        assertThat(cards.size()).isEqualTo(66);
 
         // 길 카드 수 (PathCard)
         long pathCardCount = cards.stream().filter(card -> card instanceof PathCard).count();
-        assertThat(pathCardCount).isEqualTo(44);
+        assertThat(pathCardCount).isEqualTo(39);
 
         // 파괴 카드 수 (BreakToolCard)
         long breakCardCount = cards.stream().filter(card -> card instanceof BreakToolCard).count();
@@ -74,7 +74,7 @@ class GameCardPoolTest {
         GameCardPool pool = GameCardPool.createDefaultPool(UUID.randomUUID());
 
         // 모든 카드 소진
-        for (int i = 0; i < 71; i++) {
+        for (int i = 0; i < 66; i++) {
             pool.drawCard();
         }
 

--- a/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
@@ -62,7 +62,7 @@ public class GameServiceTest {
     }
 
     @Test
-    @DisplayName("초기 카드 분배 검증: 플레이어당 6장, 카드풀 잔여 53장")
+    @DisplayName("초기 카드 분배 검증: 플레이어당 6장, 카드풀 잔여 48장")
     void testInitialCardDistribution() throws Exception {
         Map<User, UserCardDeck> userCardDecks = getUserCardDecks(gameService);
         for (User user : users) {
@@ -71,7 +71,7 @@ public class GameServiceTest {
             assertFalse(deck.getCards().isEmpty(), "카드 덱이 비어있으면 안 됨");
             assertEquals(6, deck.getCards().size(), "플레이어당 6장의 카드가 분배되어야 함");
         }
-        assertEquals(53, cardPool.getCards().size(), "카드풀에 남은 카드 수가 53장이어야 함");
+        assertEquals(48, cardPool.getCards().size(), "카드풀에 남은 카드 수가 53장이어야 함");
     }
 
     @Test


### PR DESCRIPTION
GameCardPool에 길카드(PathCard)가 막연하게 CROSSROAD 44장 추가로 유지해놨던 것을 공식 룰에 맞게 수정하였습니다.
문제가 있다면 알려주세요.

추가로 수정을 하면서 카드풀의 총 카드수도 71에서 66으로 줄어들었으므로 테스트 시 유의바랍니다. 제가 작업했던 GameCardPoolTest나 GameServiceTest 쪽은 수정을 하였는데 혹여 카드풀의 개수가 71이 아닌 경우 예외처리를 하셨다면 수정을 하셔야 합니다.