### PR TITLE
Feature/프로토타입 전용 입장 로직 구현

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameSetting.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameSetting.java
@@ -55,4 +55,8 @@ public class GameSetting extends BaseEntity {
     public void modifyTitle(String title) {
         this.title = title;
     }
+
+    public void setHost(User host) {
+        this.host = host;
+    }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -56,7 +56,8 @@ public class GameRoomServiceImpl implements GameRoomService {
         }
 
         if (gameRoom.getSetting().getHost() == null) {
-            System.out.println("[GameRoomServiceImpl] User: " + gameRoom.getSetting().getHost());
+            System.out.println("[PROTOTYPE] If host is not set, set user as host.");
+            System.out.println("[PROTOTYPE] User: " + gameRoom.getSetting().getHost());
             gameRoom.getSetting().setHost(user);
         }
 

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -55,6 +55,11 @@ public class GameRoomServiceImpl implements GameRoomService {
             throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
         }
 
+        if (gameRoom.getSetting().getHost() == null) {
+            System.out.println("[GameRoomServiceImpl] User: " + gameRoom.getSetting().getHost());
+            gameRoom.getSetting().setHost(user);
+        }
+
         gameRoom.checkJoinGameRoom(user);
 
         gameRoom.addPlayer(user);

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServicePrototype.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServicePrototype.java
@@ -1,0 +1,38 @@
+package com.goldstone.saboteur_backend.service.gameRoom;
+
+import com.goldstone.saboteur_backend.domain.game.GameRoom;
+import com.goldstone.saboteur_backend.domain.game.GameSetting;
+import com.goldstone.saboteur_backend.session.GlobalSession;
+import jakarta.annotation.PostConstruct;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 프로토타입 전용 GameRoomService입니다.
+ *
+ * <p>이 서비스는 프로토타입에서만 사용되며, 프로토타입에 사용될 더미데이터를 생성합니다.
+ *
+ * <p>정식 버전에서는 제거될 예정입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class GameRoomServicePrototype {
+    private final GlobalSession globalSession;
+
+    @PostConstruct
+    public void init() {
+        GameRoom gameRoom = new GameRoom();
+        GameSetting gameSetting = new GameSetting(gameRoom, null, "프로토타입 게임룸", 10, 3);
+
+        // 프로토타입용 게임룸 설정
+        gameRoom.setId(UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        gameRoom.setSetting(gameSetting);
+
+        // 게임룸을 글로벌 세션에 등록합니다.
+        globalSession.addGameRoomSession(gameRoom);
+
+        System.out.println("[프로토타입용 게임 룸 초기화 완료]");
+        System.out.println("[PROTOTYPE] GameRoom ID: " + gameRoom.getId());
+    }
+}


### PR DESCRIPTION
## 프로토타입 시연을 위한 게임 룸 입장 로직 추가

시연을 위한 게임 룸 입장 로직을 추가 및 개선하였습니다.
현재, 이름과 생년월일을 입력하면, 유저가 생성되고 게임 룸에 입장하는 방법으로 구현되어 있는데
**어떤 게임 룸에 입장할 것인지, 또는 게임 룸을 생성하고 입장하는 흐름이 어색하고 구현 난이도가 높아질 것이라고 생각했습니다.**

때문에, 아래와 같은 플로우로 흐름을 가져갈 예정입니다.

1. 서버가 실행되면, 게임 룸 더미데이터를 생성
    - 프로토타입 용이므로 게임 룸 ID는 항상 고정값입니다.
    - **여기서 host의 정보만 `null`인 상태로 게임 룸이 만들어집니다.**
2. 게임 룸에 입장한 첫번째 유저가 방장이 됨
3. 그 이후에 접속하는 유저는 일반 게임 유저가 됨
4. 나머지 로직은 이전과 똑같이 웹 소켓 통신을 통해 진행