### PR TITLE
feat: 낙석 및 길 카드 관련 로직 개선 및 웹소켓 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### application.yml ###
 application.yml
+
+# CardServiceWebSocketTest.java 무시
+src/main/java/com/goldstone/saboteur_backend/service/card/CardServiceWebSocketTest.java

--- a/src/main/java/com/goldstone/saboteur_backend/domain/board/Board.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/board/Board.java
@@ -56,7 +56,7 @@ public class Board {
     public boolean placeCard(int x, int y, PathCard card) {
         Cell targetCell = getOrCreateCell(x, y);
 
-        if (targetCell.canPlacePathCard(card)) {
+        if (targetCell.canPlacePathCard()) {
             targetCell.setCard(card);
             return true;
         }
@@ -91,9 +91,9 @@ public class Board {
         int dy = toCell.getY() - fromCell.getY();
 
         int direction = -1;
-        if (dx == 0 && dy == -1) direction = 0; // 위
+        if (dx == 0 && dy == 1) direction = 0; // 위
         else if (dx == 1 && dy == 0) direction = 1; // 오른쪽
-        else if (dx == 0 && dy == 1) direction = 2; // 아래
+        else if (dx == 0 && dy == -1) direction = 2; // 아래
         else if (dx == -1 && dy == 0) direction = 3; // 왼쪽
 
         if (direction == -1) return false; // 인접하지 않은 셀

--- a/src/main/java/com/goldstone/saboteur_backend/domain/board/Cell.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/board/Cell.java
@@ -57,7 +57,7 @@ public class Cell {
         return sides[3];
     }
 
-    public boolean canPlacePathCard(PathCard pathCard) {
+    public boolean canPlacePathCard() {
         for (int i = 0; i < this.sides.length; i++) {
             if (!this.sides[i].equals(PathType.EMPTY)) {
                 return false;

--- a/src/main/java/com/goldstone/saboteur_backend/domain/board/PathValidator.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/board/PathValidator.java
@@ -6,31 +6,38 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PathValidator {
-
-    public static boolean canPlacePathCard(Cell cell, PathCard pathCard) {
-        PathType[] cellSides = cell.getSides();
-        PathType[] cardSides = pathCard.getPathCardType().getSides(pathCard.isRotated());
-
+    public static boolean canPlacePathCard(Board board, Cell cell, PathCard pathCard) {
         if (cell == null || pathCard == null) {
             return false;
         }
 
-        if (cell.getCard() != null) {
+        if (!cell.canPlacePathCard()) {
             return false;
         }
 
+        // 검증을 위한 card set
+        cell.setCard(pathCard);
+
+        // up, right,down, left
+        int dx[] = {0, 1, 0, -1};
+        int dy[] = {1, 0, -1, 0};
+
         for (int i = 0; i < 4; i++) {
-            // null 값이 있는 경우 배치 불가
-            if (cellSides[i] == null || cardSides[i] == null) {
-                return false;
+            int nx = cell.getX() + dx[i];
+            int ny = cell.getY() + dy[i];
+            Cell toCell = board.getCellFromXAndY(nx, ny);
+
+            if (toCell == null) {
+                continue;
             }
 
-            // 셀의 면과 카드의 면이 일치하지 않으면 배치 불가
-            if (!cellSides[i].equals(PathType.EMPTY) && !cellSides[i].equals(cardSides[i])) {
+            if (!PathValidator.isConnected(cell, toCell, i)) {
+                cell.removeCard();
                 return false;
             }
         }
 
+        cell.removeCard();
         return true;
     }
 

--- a/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/MapCard.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/MapCard.java
@@ -18,13 +18,14 @@ public class MapCard extends ActionCard {
     public GoalCardType peekDestinationCard(Cell cell) {
         targetCell = cell;
 
-        if (targetCell == null
-                || !(targetCell.getCard() instanceof GoalCard)
-                || targetCell.isEmptyCard()) {
+        if (targetCell == null || targetCell.isEmptyCard()) {
             throw new BusinessException(CardErrorCode.INVALID_GOAL_CARD);
         }
 
         GoalCard goalCard = (GoalCard) targetCell.getCard();
+        if (!(goalCard instanceof GoalCard)){
+            throw new BusinessException(CardErrorCode.INVALID_GOAL_CARD);
+        }
         return goalCard.getType();
     }
 

--- a/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/MapCard.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/MapCard.java
@@ -1,6 +1,7 @@
 package com.goldstone.saboteur_backend.domain.card.actionCard;
 
 import com.goldstone.saboteur_backend.domain.board.Cell;
+import com.goldstone.saboteur_backend.domain.card.Card;
 import com.goldstone.saboteur_backend.domain.card.GoalCard;
 import com.goldstone.saboteur_backend.domain.enums.ActionCardType;
 import com.goldstone.saboteur_backend.domain.enums.GoalCardType;
@@ -22,10 +23,13 @@ public class MapCard extends ActionCard {
             throw new BusinessException(CardErrorCode.INVALID_GOAL_CARD);
         }
 
-        GoalCard goalCard = (GoalCard) targetCell.getCard();
-        if (!(goalCard instanceof GoalCard)){
+        Card card = targetCell.getCard();
+
+        if (!(card instanceof GoalCard)){
             throw new BusinessException(CardErrorCode.INVALID_GOAL_CARD);
         }
+        GoalCard goalCard = (GoalCard) card;
+
         return goalCard.getType();
     }
 

--- a/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/RepairToolCard.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/card/actionCard/RepairToolCard.java
@@ -6,9 +6,12 @@ import com.goldstone.saboteur_backend.domain.enums.TargetToolType;
 import com.goldstone.saboteur_backend.domain.user.User;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.CardErrorCode;
+import lombok.Getter;
+
 import java.util.HashSet;
 import java.util.Set;
 
+@Getter
 public class RepairToolCard extends ActionCard {
     private final Set<TargetToolType> repairableTools;
     private TargetToolType targetTool;

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/CardServiceWebSocketTest.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/CardServiceWebSocketTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/CardServiceWebSocketTest.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/CardServiceWebSocketTest.java
@@ -4,6 +4,9 @@ import com.goldstone.saboteur_backend.domain.board.Board;
 import com.goldstone.saboteur_backend.domain.card.Card;
 import com.goldstone.saboteur_backend.domain.card.PathCard;
 import com.goldstone.saboteur_backend.domain.card.actionCard.BreakToolCard;
+import com.goldstone.saboteur_backend.domain.card.actionCard.FallingRockCard;
+import com.goldstone.saboteur_backend.domain.card.actionCard.MapCard;
+import com.goldstone.saboteur_backend.domain.card.actionCard.RepairToolCard;
 import com.goldstone.saboteur_backend.domain.enums.PathCardType;
 import com.goldstone.saboteur_backend.domain.enums.TargetToolType;
 import com.goldstone.saboteur_backend.domain.game.GameRoom;
@@ -12,6 +15,7 @@ import com.goldstone.saboteur_backend.domain.user.UserCardDeck;
 import com.goldstone.saboteur_backend.session.GlobalSession;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -50,9 +54,25 @@ public class CardServiceWebSocketTest {
         BreakToolCard card = new BreakToolCard(TargetToolType.PICKAX);
         UUID cardId = card.getCardId();
 
+        HashSet<TargetToolType> set = new HashSet<>();
+        set.add(TargetToolType.PICKAX);
+        RepairToolCard card1 = new RepairToolCard(set);
+        card1.selectTool(TargetToolType.PICKAX);
+        UUID cardId1 = card1.getCardId();
+
+        MapCard card2 = new MapCard();
+        UUID cardId2 = card2.getCardId();
+
+        FallingRockCard card3 = new FallingRockCard();
+        UUID cardId3 = card3.getCardId();
+
         // 카드 등록
         List<Card> cardList = new ArrayList<>();
         cardList.add(card);
+        cardList.add(card1);
+        cardList.add(card2);
+        cardList.add(card3);
+
         UserCardDeck userDeck = new UserCardDeck(user, cardList);
         user.setCardDeck(userDeck);
 
@@ -62,26 +82,35 @@ public class CardServiceWebSocketTest {
         globalSession.addGameRoomSession(gameRoom);
         globalSession.addGameBoardSession(gameRoom, board);
 
-        // 콘솔 출력
-        System.out.println("[테스트 환경 초기화 완료]");
-        System.out.println("[DEBUG] 카드 ID: " + cardId);
-        System.out.println("[DEBUG] 유저 ID: " + userId);
-        System.out.println("[DEBUG] 타겟 유저 ID: " + targetUserId);
-        System.out.println("[DEBUG] 게임룸 ID: " + roomId);
-        System.out.println();
-        System.out.println("Postman WebSocket 요청 예시:");
         System.out.println(
                 """
-                {
-                  "userId": "%s",
-                  "cardId": "%s",
-                  "cardType": "ACTION",
-                  "actionCardType": "DESTROY",
-                  "targetUserId": "%s",
-                  "roomId": "%s"
-                }
-                """
+                        도구 고장 카드
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "ACTION",
+                          "actionCardType": "DESTROY",
+                          "targetUserId": "%s",
+                          "roomId": "%s"
+                        }
+                        """
                         .formatted(userId, cardId, targetUserId, roomId));
+
+
+        System.out.println(
+                """
+                        도구 수리 카드
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "ACTION",
+                          "actionCardType": "REPAIR",
+                          "targetUserId": "%s",
+                          "roomId": "%s"
+                        }
+                        """
+                        .formatted(userId, cardId1, targetUserId, roomId, card1));
+        System.out.println("repairableTools: " + card1.getRepairableTools());
 
         // 길카드 테스트
         PathCard pathCard = new PathCard(PathCardType.CROSSROAD, false); // 예: 십자형 카드
@@ -93,15 +122,68 @@ public class CardServiceWebSocketTest {
         System.out.println("Postman WebSocket 길카드 설치 요청 예시:");
         System.out.println(
                 """
-                {
-                  "userId": "%s",
-                  "cardId": "%s",
-                  "cardType": "PATH",
-                  "roomId": "%s",
-                  "targetCellX": 2,
-                  "targetCellY": 1
-                }
-                """
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "PATH",
+                          "roomId": "%s",
+                          "targetCellX": 2,
+                          "targetCellY": 1
+                        }
+                        """
                         .formatted(userId, pathCardId, roomId));
+
+
+        PathCard pathCard2 = new PathCard(PathCardType.CROSSROAD, false); // 예: 십자형 카드
+        UUID pathCardId2 = pathCard2.getCardId();
+        cardList.add(pathCard2); // 핸드에 추가
+
+        System.out.println("[DEBUG] 길카드 ID: " + pathCardId2);
+        System.out.println();
+        System.out.println("Postman WebSocket 길카드 설치 요청 예시:");
+        System.out.println(
+                """
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "PATH",
+                          "roomId": "%s",
+                          "targetCellX": 2,
+                          "targetCellY": 1
+                        }
+                        """
+                        .formatted(userId, pathCardId2, roomId));
+
+
+        System.out.println(
+                """
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "ACTION",
+                          "roomId": "%s",
+                          "targetCellX": 8,
+                          "targetCellY": 2
+                        }
+                        """
+                        .formatted(userId, cardId2, roomId));
+
+        System.out.println(
+                """
+                        {
+                          "userId": "%s",
+                          "cardId": "%s",
+                          "cardType": "ACTION",
+                          "roomId": "%s",
+                          "targetCellX": 2,
+                          "targetCellY": 1
+                        }
+                        """
+                        .formatted(userId, cardId3, roomId));
+
+
     }
+
 }
+
+

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/PathCardService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/PathCardService.java
@@ -20,8 +20,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PathCardService {
     private final GlobalSession globalSession;
-    private final PathValidator pathValidator;
-
     public UseCardResponse use(UseCardRequest request) {
         User user = globalSession.getUserSession(request.getUserId());
         Board board = globalSession.getGameBoardSession(request.getRoomId());
@@ -42,7 +40,7 @@ public class PathCardService {
             throw new BusinessException(BoardErrorCode.INVALID_PATH_PLACEMENT);
         }
 
-        if (!(pathValidator.canPlacePathCard(targetCell, pathCard))) {
+        if (!(PathValidator.canPlacePathCard(board, targetCell, pathCard))) {
             throw new BusinessException(CardErrorCode.INVALID_PATH_CARD);
         }
 

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/actionCard/ActionCardService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/actionCard/ActionCardService.java
@@ -63,7 +63,7 @@ public class ActionCardService {
             }
             default -> throw new BusinessException(CardErrorCode.INVALID_CARD_TYPE);
         }
-        ;
+
 
         user.getCardDeck().useCard(actionCard);
 

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/actionCard/FallingRockCardService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/actionCard/FallingRockCardService.java
@@ -3,6 +3,8 @@ package com.goldstone.saboteur_backend.service.card.actionCard;
 import com.goldstone.saboteur_backend.domain.board.Board;
 import com.goldstone.saboteur_backend.domain.board.Cell;
 import com.goldstone.saboteur_backend.domain.card.Card;
+import com.goldstone.saboteur_backend.domain.card.GoalCard;
+import com.goldstone.saboteur_backend.domain.card.StartCard;
 import com.goldstone.saboteur_backend.domain.card.actionCard.FallingRockCard;
 import com.goldstone.saboteur_backend.domain.user.User;
 import com.goldstone.saboteur_backend.dtos.card.request.CellTargetCardRequest;
@@ -35,6 +37,12 @@ public class FallingRockCardService {
         int y = request.getTargetCellY();
 
         Cell cell = board.getOrCreateCell(x, y);
+
+        Card targetCard = cell.getCard();
+
+        if (targetCard == null || targetCard instanceof GoalCard || targetCard instanceof StartCard) {
+            throw new BusinessException(CardErrorCode.INVALID_ACTION_CARD);
+        }
 
         ((FallingRockCard) card).use(cell);
 

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/CardEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/CardEventRegister.java
@@ -6,6 +6,7 @@ import com.goldstone.saboteur_backend.dtos.card.request.PathCardRequest;
 import com.goldstone.saboteur_backend.dtos.card.request.UserTargetRequest;
 import com.goldstone.saboteur_backend.dtos.card.response.UseCardResponse;
 import com.goldstone.saboteur_backend.exception.BusinessException;
+import com.goldstone.saboteur_backend.exception.responseDto.ErrorResponse;
 import com.goldstone.saboteur_backend.service.card.PathCardService;
 import com.goldstone.saboteur_backend.service.card.actionCard.ActionCardService;
 import com.goldstone.saboteur_backend.socketIo.SocketIoService;
@@ -28,7 +29,7 @@ public class CardEventRegister implements SocketEventRegister {
                 UseCardResponse response = actionCardService.useActionCard(request);
                 socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
             } catch (BusinessException e) {
-                client.sendEvent("cardError", e.getMessage());
+                client.sendEvent("errorEvent", new ErrorResponse(e.getErrorCode()));
             }
         });
 
@@ -38,7 +39,7 @@ public class CardEventRegister implements SocketEventRegister {
                 UseCardResponse response = actionCardService.useActionCard(request);
                 socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
             } catch (BusinessException e) {
-                client.sendEvent("cardError", e.getMessage());
+                client.sendEvent("errorEvent", new ErrorResponse(e.getErrorCode()));
             }
         });
 
@@ -46,9 +47,9 @@ public class CardEventRegister implements SocketEventRegister {
         server.addEventListener("useMapCard", CellTargetCardRequest.class, (client, request, ackSender) -> {
             try {
                 UseCardResponse response = actionCardService.useActionCard(request);
-                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+                client.sendEvent("cardUsed", response);
             } catch (BusinessException e) {
-                client.sendEvent("cardError", e.getMessage());
+                client.sendEvent("errorEvent", new ErrorResponse(e.getErrorCode()));
             }
         });
 
@@ -58,7 +59,7 @@ public class CardEventRegister implements SocketEventRegister {
                 UseCardResponse response = actionCardService.useActionCard(request);
                 socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
             } catch (BusinessException e) {
-                client.sendEvent("cardError", e.getMessage());
+                client.sendEvent("errorEvent", new ErrorResponse(e.getErrorCode()));
             }
         });
 
@@ -68,7 +69,7 @@ public class CardEventRegister implements SocketEventRegister {
                 UseCardResponse response = pathCardService.use(request);
                 socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
             } catch (BusinessException e) {
-                client.sendEvent("cardError", e.getMessage());
+                client.sendEvent("errorEvent", new ErrorResponse(e.getErrorCode()));
             }
         });
     }

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/CardEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/CardEventRegister.java
@@ -5,6 +5,7 @@ import com.goldstone.saboteur_backend.dtos.card.request.CellTargetCardRequest;
 import com.goldstone.saboteur_backend.dtos.card.request.PathCardRequest;
 import com.goldstone.saboteur_backend.dtos.card.request.UserTargetRequest;
 import com.goldstone.saboteur_backend.dtos.card.response.UseCardResponse;
+import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.service.card.PathCardService;
 import com.goldstone.saboteur_backend.service.card.actionCard.ActionCardService;
 import com.goldstone.saboteur_backend.socketIo.SocketIoService;
@@ -18,57 +19,57 @@ public class CardEventRegister implements SocketEventRegister {
     private final PathCardService pathCardService;
     private final SocketIoService socketIoService;
 
+
     @Override
     public void registerEvents(SocketIOServer server) {
+        // 1. 도구 파괴 카드
+        server.addEventListener("useBreakToolCard", UserTargetRequest.class, (client, request, ackSender) -> {
+            try {
+                UseCardResponse response = actionCardService.useActionCard(request);
+                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+            } catch (BusinessException e) {
+                client.sendEvent("cardError", e.getMessage());
+            }
+        });
 
-        // 1. 도구 파괴 카드 (DESTROY)
-        server.addEventListener(
-                "useBreakToolCard",
-                UserTargetRequest.class,
-                (client, request, ackSender) -> {
-                    UseCardResponse response = actionCardService.useActionCard(request);
-                    socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
-                    ackSender.sendAckData(response);
-                });
+        // 2. 도구 수리 카드
+        server.addEventListener("useRepairToolCard", UserTargetRequest.class, (client, request, ackSender) -> {
+            try {
+                UseCardResponse response = actionCardService.useActionCard(request);
+                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+            } catch (BusinessException e) {
+                client.sendEvent("cardError", e.getMessage());
+            }
+        });
 
-        // 2. 도구 수리 카드 (REPAIR)
-        server.addEventListener(
-                "useRepairToolCard",
-                UserTargetRequest.class,
-                (client, request, ackSender) -> {
-                    UseCardResponse response = actionCardService.useActionCard(request);
-                    socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
-                    ackSender.sendAckData(response);
-                });
+        // 3. 지도 카드
+        server.addEventListener("useMapCard", CellTargetCardRequest.class, (client, request, ackSender) -> {
+            try {
+                UseCardResponse response = actionCardService.useActionCard(request);
+                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+            } catch (BusinessException e) {
+                client.sendEvent("cardError", e.getMessage());
+            }
+        });
 
-        // 3. 지도 카드 (MAP)
-        server.addEventListener(
-                "useMapCard",
-                CellTargetCardRequest.class,
-                (client, request, ackSender) -> {
-                    UseCardResponse response = actionCardService.useActionCard(request);
-                    socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
-                    ackSender.sendAckData(response);
-                });
+        // 4. 낙석 카드
+        server.addEventListener("useFallingRockCard", CellTargetCardRequest.class, (client, request, ackSender) -> {
+            try {
+                UseCardResponse response = actionCardService.useActionCard(request);
+                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+            } catch (BusinessException e) {
+                client.sendEvent("cardError", e.getMessage());
+            }
+        });
 
-        // 4. 낙석 카드 (FALLING_ROCK)
-        server.addEventListener(
-                "useFallingRockCard",
-                CellTargetCardRequest.class,
-                (client, request, ackSender) -> {
-                    UseCardResponse response = actionCardService.useActionCard(request);
-                    socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
-                    ackSender.sendAckData(response);
-                });
-
-        // 5. 길카드 (PATH)
-        server.addEventListener(
-                "usePathCard",
-                PathCardRequest.class,
-                (client, request, ackSender) -> {
-                    UseCardResponse response = pathCardService.use(request);
-                    socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
-                    ackSender.sendAckData(response);
-                });
+        // 5. 길 카드
+        server.addEventListener("usePathCard", PathCardRequest.class, (client, request, ackSender) -> {
+            try {
+                UseCardResponse response = pathCardService.use(request);
+                socketIoService.sendBroadCast(request.getRoomId(), "cardUsed", response);
+            } catch (BusinessException e) {
+                client.sendEvent("cardError", e.getMessage());
+            }
+        });
     }
 }


### PR DESCRIPTION
- 낙석 카드: 출발/도착지 카드가 위치한 셀에는 사용 불가하도록 로직 추가
- PathValidator.isConnected() 수정
- Board.canPlacePathCard() 조건 수정
- CardEventRegister에서 ack 제거, client.sendEvent로 예외 전송
- CardServiceWebSocketTest에 지도 카드 및 낙석 카드 테스트 케이스 추가