### PR TITLE
feat: 게임에 접속한 플레이어 목록 조회 이벤트 구현

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/request/GetGameRoomUsersRequestDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/request/GetGameRoomUsersRequestDto.java
@@ -1,0 +1,13 @@
+package com.goldstone.saboteur_backend.dtos.gameRoom.request;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class GetGameRoomUsersRequestDto {
+    private UUID gameRoomId;
+}

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/GetGameRoomUsersResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/gameRoom/response/GetGameRoomUsersResponseDto.java
@@ -1,0 +1,26 @@
+package com.goldstone.saboteur_backend.dtos.gameRoom.response;
+
+import com.goldstone.saboteur_backend.domain.game.GameRoom;
+import com.goldstone.saboteur_backend.domain.mapping.UserGameRoom;
+import com.goldstone.saboteur_backend.dtos.userGameRoom.response.UserGameRoomInfoResponseDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetGameRoomUsersResponseDto {
+    private final String gameRoomId;
+    private final UserGameRoomInfoResponseDto[] users;
+
+    public static GetGameRoomUsersResponseDto of(
+            GameRoom gameRoom, List<UserGameRoom> userGameRooms) {
+        return GetGameRoomUsersResponseDto.builder()
+                .gameRoomId(gameRoom.getId().toString())
+                .users(
+                        userGameRooms.stream()
+                                .map(UserGameRoomInfoResponseDto::of)
+                                .toArray(UserGameRoomInfoResponseDto[]::new))
+                .build();
+    }
+}

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/userGameRoom/response/UserGameRoomInfoResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/userGameRoom/response/UserGameRoomInfoResponseDto.java
@@ -1,0 +1,18 @@
+package com.goldstone.saboteur_backend.dtos.userGameRoom.response;
+
+import com.goldstone.saboteur_backend.domain.mapping.UserGameRoom;
+import com.goldstone.saboteur_backend.dtos.user.response.UserInfoResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserGameRoomInfoResponseDto {
+    private final UserInfoResponseDto user;
+
+    public static UserGameRoomInfoResponseDto of(UserGameRoom userGameRoom) {
+        return UserGameRoomInfoResponseDto.builder()
+                .user(UserInfoResponseDto.from(userGameRoom.getUser()))
+                .build();
+    }
+}

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomService.java
@@ -5,8 +5,11 @@ import com.goldstone.saboteur_backend.domain.game.GameRoom;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.CreateGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
+import java.util.UUID;
 
 public interface GameRoomService {
+    GameRoom getGameRoomById(UUID gameRoomId);
+
     GameRoom createGameRoom(CreateGameRoomRequestDto dto);
 
     GameRoom joinGameRoom(SocketIOClient client, JoinGameRoomRequestDto dto);

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -28,6 +28,14 @@ public class GameRoomServiceImpl implements GameRoomService {
     @Autowired private final GlobalSession globalSession;
     private final SocketIoService socketIoService;
 
+    public GameRoom getGameRoomById(UUID id) {
+        GameRoom gameRoom = this.globalSession.getGameRoomSession(id);
+        if (gameRoom == null) {
+            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
+        }
+        return gameRoom;
+    }
+
     @Override
     public GameRoom createGameRoom(CreateGameRoomRequestDto dto) {
         User host = this.globalSession.getUserSession(dto.getUserId());
@@ -53,10 +61,7 @@ public class GameRoomServiceImpl implements GameRoomService {
             throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
         }
 
-        GameRoom gameRoom = this.globalSession.getGameRoomSession(dto.getGameRoomId());
-        if (gameRoom == null) {
-            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
-        }
+        GameRoom gameRoom = this.getGameRoomById(dto.getGameRoomId());
 
         if (gameRoom.getSetting().getHost() == null) {
             System.out.println("[PROTOTYPE] If host is not set, set user as host.");
@@ -72,11 +77,9 @@ public class GameRoomServiceImpl implements GameRoomService {
         return gameRoom;
     }
 
+    @Override
     public GameRoom startGame(StartGameRequestDto dto) {
-        GameRoom gameRoom = this.globalSession.getGameRoomSession(dto.getGameRoomId());
-        if (gameRoom == null) {
-            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
-        }
+        GameRoom gameRoom = this.getGameRoomById(dto.getGameRoomId());
         gameRoom.canStartGame(dto.getUserId());
         gameRoom.startGame();
 
@@ -87,10 +90,7 @@ public class GameRoomServiceImpl implements GameRoomService {
 
     /** 라운드 초기화: 역할, 보드, 턴매니저, 카드풀, 카드 분배 등 */
     public void initRound(UUID gameRoomId) {
-        GameRoom gameRoom = this.globalSession.getGameRoomSession(gameRoomId);
-        if (gameRoom == null) {
-            throw new BusinessException(GameRoomErrorCode.GAME_ROOM_NOT_FOUND);
-        }
+        GameRoom gameRoom = this.getGameRoomById(gameRoomId);
 
         // 1. 기존 세션 제거
         globalSession.removeGameBoardSession(gameRoomId);

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameRoomEventRegister.java
@@ -2,9 +2,11 @@ package com.goldstone.saboteur_backend.socketIo.eventRegister;
 
 import com.corundumstudio.socketio.SocketIOServer;
 import com.goldstone.saboteur_backend.domain.game.GameRoom;
+import com.goldstone.saboteur_backend.dtos.gameRoom.request.GetGameRoomUsersRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.JoinGameRoomRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.request.StartGameRequestDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.response.GameRoomInfoResponseDto;
+import com.goldstone.saboteur_backend.dtos.gameRoom.response.GetGameRoomUsersResponseDto;
 import com.goldstone.saboteur_backend.dtos.gameRoom.response.JoinGameRoomResponseDto;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.ErrorCode;
@@ -22,6 +24,7 @@ public class GameRoomEventRegister implements SocketEventRegister {
 
     @Override
     public void registerEvents(SocketIOServer server) {
+        // 게임 룸 참여 이벤트
         server.addEventListener(
                 "joinGameRoom",
                 JoinGameRoomRequestDto.class,
@@ -39,6 +42,8 @@ public class GameRoomEventRegister implements SocketEventRegister {
                         }
                     }
                 });
+
+        // 게임 시작 이벤트
         server.addEventListener(
                 "startGame",
                 StartGameRequestDto.class,
@@ -50,6 +55,30 @@ public class GameRoomEventRegister implements SocketEventRegister {
                                 gameRoom.getId(),
                                 "gameStarted",
                                 GameRoomInfoResponseDto.from(gameRoom));
+                    } catch (Exception e) {
+                        if (e instanceof BusinessException) {
+                            ErrorCode errorCode = ((BusinessException) e).getErrorCode();
+                            client.sendEvent("errorEvent", new ErrorResponse(errorCode));
+                        } else {
+                            client.sendEvent("errorEvent", ErrorResponse.internalServerError());
+                        }
+                    }
+                });
+
+        // 게임 룸에 참여한 유저 목록 조회 이벤트
+        server.addEventListener(
+                "getGameRoomUsers",
+                GetGameRoomUsersRequestDto.class,
+                (client, data, ackSender) -> {
+                    try {
+                        GameRoom gameRoom =
+                                this.gameRoomService.getGameRoomById(data.getGameRoomId());
+
+                        this.socketIoService.sendBroadCast(
+                                gameRoom.getId(),
+                                "gameRoomUsers",
+                                GetGameRoomUsersResponseDto.of(
+                                        gameRoom, gameRoom.getUserGameRooms()));
                     } catch (Exception e) {
                         if (e instanceof BusinessException) {
                             ErrorCode errorCode = ((BusinessException) e).getErrorCode();


### PR DESCRIPTION
아까 이야기 나눴던 것 중에 접속 유저 목록을 조회하는 기능을 구현하지 않기로 했었는데,
프론트에서 필요한 이벤트를 생각하니 백엔드에서 `getGameRoomUsers` 이벤트가 필요할 것 같아 구현하였습니다.

크게 달라지거나 하는 별 기능은 없지만, 약간의 리팩토링을 하였습니다.

---

### `GameRoomServiceImpl`에 `getGameRoomById` 메서드 구현
- `gameRoom` 조회하고 `if (gameRoom == null)` 로직이 너무 반복되는 것 같아, 메서드로 묶었습니다.
- 일단 눈에 보이는 비슷한 로직들은 메서드로 바꿔주었습니다.

---

### `getGameRoomUsers` 이벤트 구현