### PR TITLE
Feature: 게임 종료 시 금덩이 분배 로직 구현

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/domain/game/GameTurnManager.java
+++ b/src/main/java/com/goldstone/saboteur_backend/domain/game/GameTurnManager.java
@@ -3,6 +3,7 @@ package com.goldstone.saboteur_backend.domain.game;
 import com.goldstone.saboteur_backend.domain.mapping.UserGameRoom;
 import com.goldstone.saboteur_backend.domain.user.User;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -21,5 +22,9 @@ public class GameTurnManager {
     public User nextTurn() {
         currentTurnIndex = (currentTurnIndex + 1) % userGameRooms.size();
         return getCurrentTurnUser();
+    }
+
+    public List<User> getTurnOrder() {
+        return userGameRooms.stream().map(UserGameRoom::getUser).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/game/request/SelectGoldCardRequestDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/game/request/SelectGoldCardRequestDto.java
@@ -1,0 +1,13 @@
+package com.goldstone.saboteur_backend.dtos.game.request;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SelectGoldCardRequestDto {
+    private UUID gameRoomId;
+    private UUID userId;
+    private UUID selectedGoldCardId;
+}

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/game/response/GetGameStateResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/game/response/GetGameStateResponseDto.java
@@ -1,5 +1,6 @@
 package com.goldstone.saboteur_backend.dtos.game.response;
 
+import com.goldstone.saboteur_backend.domain.card.Card;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -17,5 +18,5 @@ public class GetGameStateResponseDto {
     private String currentPlayerName;
     private Map<UUID, Integer> playerCardCounts;
     private int cardPoolRemaining;
-    private List<UUID> myCardIds; // 내 손패 카드 id 목록
+    private List<Card> myCards; // 내 손패 카드 id 목록
 }

--- a/src/main/java/com/goldstone/saboteur_backend/dtos/game/response/SelectGoldCardResponseDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/game/response/SelectGoldCardResponseDto.java
@@ -1,0 +1,15 @@
+package com.goldstone.saboteur_backend.dtos.game.response;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SelectGoldCardResponseDto {
+    private boolean success;
+    private String message;
+    private List<UUID> remainingGoldCardIds;
+    private UUID nextPlayerUserId;
+}

--- a/src/main/java/com/goldstone/saboteur_backend/service/card/PathCardService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/card/PathCardService.java
@@ -12,7 +12,9 @@ import com.goldstone.saboteur_backend.dtos.card.response.UseCardResponse;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.BoardErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.CardErrorCode;
+import com.goldstone.saboteur_backend.service.board.BoardService;
 import com.goldstone.saboteur_backend.session.GlobalSession;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PathCardService {
     private final GlobalSession globalSession;
+    private final BoardService boardService;
 
     public UseCardResponse use(UseCardRequest request) {
         User user = globalSession.getUserSession(request.getUserId());
@@ -47,6 +50,11 @@ public class PathCardService {
 
         targetCell.setCard(pathCard);
         user.getCardDeck().useCard(pathCard);
+
+        List<Cell> reachableGoals = boardService.getReachableGoals(board);
+        if (!reachableGoals.isEmpty()) {
+            globalSession.setGoldFinder(request.getRoomId(), user);
+        }
 
         return new UseCardResponse(
                 null, null, null, String.format("(%d, %d) 위치에 길카드가 놓였습니다.", x, y));

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameHandleService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameHandleService.java
@@ -1,13 +1,11 @@
 package com.goldstone.saboteur_backend.service.game;
 
 import com.corundumstudio.socketio.SocketIOClient;
-import com.goldstone.saboteur_backend.dtos.game.request.DiscardCardRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.GetGameStateRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.NextTurnRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.PlayCardRequestDto;
+import com.goldstone.saboteur_backend.dtos.game.request.*;
 import com.goldstone.saboteur_backend.dtos.game.response.GetGameStateResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.NextTurnResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.PlayCardResponseDto;
+import com.goldstone.saboteur_backend.dtos.game.response.SelectGoldCardResponseDto;
 
 public interface GameHandleService {
     PlayCardResponseDto playCard(SocketIOClient client, PlayCardRequestDto dto) throws Exception;
@@ -18,5 +16,8 @@ public interface GameHandleService {
             throws Exception;
 
     PlayCardResponseDto discardCard(SocketIOClient client, DiscardCardRequestDto dto)
+            throws Exception;
+
+    SelectGoldCardResponseDto selectGoldCard(SocketIOClient client, SelectGoldCardRequestDto dto)
             throws Exception;
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -12,24 +12,19 @@ import com.goldstone.saboteur_backend.domain.game.GoldCardDeck;
 import com.goldstone.saboteur_backend.domain.mapping.UserGameRole;
 import com.goldstone.saboteur_backend.domain.user.User;
 import com.goldstone.saboteur_backend.domain.user.UserCardDeck;
-import com.goldstone.saboteur_backend.dtos.game.request.DiscardCardRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.GetGameStateRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.NextTurnRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.PlayCardRequestDto;
+import com.goldstone.saboteur_backend.dtos.game.request.*;
 import com.goldstone.saboteur_backend.dtos.game.response.GetGameStateResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.NextTurnResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.PlayCardResponseDto;
+import com.goldstone.saboteur_backend.dtos.game.response.SelectGoldCardResponseDto;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.UserErrorCode;
 import com.goldstone.saboteur_backend.service.board.BoardService;
 import com.goldstone.saboteur_backend.session.GlobalSession;
 import com.goldstone.saboteur_backend.socketIo.SocketIoService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -73,12 +68,13 @@ public class GameServiceImpl implements GameHandleService {
     private void broadcastGameEnded(GameRoom gameRoom) {
         List<UserGameRole> roles = globalSession.getRoleAssignment(gameRoom.getId());
         if (roles == null) return;
-        Map<UUID, String> roleMap = new HashMap<>();
-        for (UserGameRole role : roles) {
-            roleMap.put(role.getUser().getId(), role.getRole().name());
-        }
+        Map<UUID, String> roleMap =
+                roles.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        role -> role.getUser().getId(),
+                                        role -> role.getRole().name()));
 
-        // 승리 팀 판단
         Board board = this.globalSession.getGameBoardSession(gameRoom.getId());
         if (board == null) {
             throw new BusinessException(GameRoomErrorCode.GAME_BOARD_NOT_FOUND);
@@ -86,27 +82,123 @@ public class GameServiceImpl implements GameHandleService {
         boolean isMinerVictory = !boardService.getReachableGoals(board).isEmpty();
         String winningTeam = isMinerVictory ? "MINER" : "SABOTEUR";
 
-        // 금덩이 분배
         GoldCardDeck goldDeck = globalSession.getGoldDeckSession(gameRoom.getId());
-        if (goldDeck != null && isMinerVictory) {
-            List<User> miners = new ArrayList<>();
-            for (UserGameRole role : roles) {
-                if (role.getRole() == GameRole.MINER) {
-                    miners.add(role.getUser());
-                }
-            }
-            List<GoldCard> golds = goldDeck.drawGoldCards(miners.size());
-            for (int i = 0; i < miners.size() && i < golds.size(); i++) {
-                miners.get(i).addGoldCard(golds.get(i));
+        if (goldDeck != null) {
+            if (isMinerVictory) {
+                distributeGoldToMiners(gameRoom, roles, goldDeck);
+            } else {
+                distributeGoldToSaboteurs(roles);
             }
         }
-
-        // 결과 브로드캐스트 (역할, 승리팀, 메시지 등)
         Map<String, Object> result = new HashMap<>();
         result.put("roles", roleMap);
         result.put("winningTeam", winningTeam);
         result.put("message", "게임이 종료되었습니다.");
         socketIoService.sendBroadCast(gameRoom.getId(), "gameEnded", result);
+    }
+
+    // 광부 분배: 금 발견자 → 턴 순서대로 원하는 금 카드 선택
+    private void distributeGoldToMiners(
+            GameRoom gameRoom, List<UserGameRole> roles, GoldCardDeck goldDeck) {
+        User goldFinder = globalSession.getGoldFinder(gameRoom.getId());
+        if (goldFinder == null) return;
+
+        List<User> miners =
+                roles.stream()
+                        .filter(role -> role.getRole() == GameRole.MINER)
+                        .map(UserGameRole::getUser)
+                        .toList();
+        if (miners.isEmpty()) return;
+
+        List<User> orderedMiners = new ArrayList<>();
+        orderedMiners.add(goldFinder);
+        GameTurnManager turnManager = globalSession.getTurnManagerSession(gameRoom.getId());
+        for (User user : turnManager.getTurnOrder()) {
+            if (miners.contains(user) && !user.equals(goldFinder)) {
+                orderedMiners.add(user);
+            }
+        }
+
+        List<GoldCard> golds = goldDeck.drawGoldCards(miners.size());
+
+        GoldDistributionState state = new GoldDistributionState();
+        state.minerQueue = new LinkedList<>(orderedMiners);
+        state.availableGoldCards = new ArrayList<>(golds);
+        globalSession.setGoldDistributionState(gameRoom.getId(), state);
+
+        requestGoldCardSelection(gameRoom.getId());
+    }
+
+    private void requestGoldCardSelection(UUID gameRoomId) {
+        GoldDistributionState state = globalSession.getGoldDistributionState(gameRoomId);
+        if (state == null || state.minerQueue.isEmpty() || state.availableGoldCards.isEmpty()) {
+            globalSession.removeGoldDistributionState(gameRoomId);
+            return;
+        }
+        User currentMiner = state.minerQueue.peek();
+        socketIoService.sendEventToUser(
+                currentMiner.getId(),
+                "selectGoldCard",
+                Map.of("availableGoldCards", state.availableGoldCards));
+        scheduleGoldCardAutoSelect(gameRoomId, currentMiner.getId());
+    }
+
+    public void handleGoldCardSelection(UUID gameRoomId, UUID userId, UUID selectedGoldCardId) {
+        GoldDistributionState state = globalSession.getGoldDistributionState(gameRoomId);
+        if (state == null) return;
+        User currentMiner = state.minerQueue.peek();
+        if (currentMiner == null || !currentMiner.getId().equals(userId)) return;
+
+        GoldCard selectedCard =
+                state.availableGoldCards.stream()
+                        .filter(card -> card.getId().equals(selectedGoldCardId))
+                        .findFirst()
+                        .orElse(null);
+        if (selectedCard == null) return;
+
+        currentMiner.addGoldCard(selectedCard);
+        state.availableGoldCards.remove(selectedCard);
+        state.minerQueue.poll();
+        requestGoldCardSelection(gameRoomId);
+    }
+
+    private void scheduleGoldCardAutoSelect(UUID gameRoomId, UUID userId) {
+        new Thread(
+                        () -> {
+                            try {
+                                Thread.sleep(10_000); // 10초 타임아웃
+                                GoldDistributionState state =
+                                        globalSession.getGoldDistributionState(gameRoomId);
+                                if (state == null) return;
+                                User currentMiner = state.minerQueue.peek();
+                                if (currentMiner == null || !currentMiner.getId().equals(userId))
+                                    return;
+                                GoldCard autoSelected = state.availableGoldCards.get(0);
+                                handleGoldCardSelection(gameRoomId, userId, autoSelected.getId());
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        })
+                .start();
+    }
+
+    private void distributeGoldToSaboteurs(List<UserGameRole> roles) {
+        List<User> saboteurs =
+                roles.stream()
+                        .filter(role -> role.getRole() == GameRole.SABOTEUR)
+                        .map(UserGameRole::getUser)
+                        .toList();
+        int saboteurCount = saboteurs.size();
+        int goldPerSaboteur =
+                switch (saboteurCount) {
+                    case 1 -> 4;
+                    case 2, 3 -> 3;
+                    case 4 -> 2;
+                    default -> 0;
+                };
+        for (User saboteur : saboteurs) {
+            saboteur.setGoldScore(saboteur.getGoldScore() + goldPerSaboteur);
+        }
     }
 
     @Override
@@ -295,6 +387,59 @@ public class GameServiceImpl implements GameHandleService {
             return responseDto;
         } catch (Exception e) {
             client.sendEvent("error", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public SelectGoldCardResponseDto selectGoldCard(
+            SocketIOClient client, SelectGoldCardRequestDto dto) throws Exception {
+        try {
+            GoldDistributionState state =
+                    globalSession.getGoldDistributionState(dto.getGameRoomId());
+            if (state == null) {
+                throw new Exception("금덩이 분배가 진행 중이지 않습니다.");
+            }
+            User currentMiner = state.minerQueue.peek();
+            if (currentMiner == null || !currentMiner.getId().equals(dto.getUserId())) {
+                throw new Exception("잘못된 차례입니다.");
+            }
+
+            GoldCard selectedCard =
+                    state.availableGoldCards.stream()
+                            .filter(card -> card.getId().equals(dto.getSelectedGoldCardId()))
+                            .findFirst()
+                            .orElseThrow(() -> new Exception("선택한 금덩이 카드를 찾을 수 없습니다."));
+
+            currentMiner.addGoldCard(selectedCard);
+            state.availableGoldCards.remove(selectedCard);
+            state.minerQueue.poll();
+
+            List<UUID> remainingCardIds =
+                    state.availableGoldCards.stream().map(GoldCard::getId).toList();
+            UUID nextPlayerId =
+                    !state.minerQueue.isEmpty() ? state.minerQueue.peek().getId() : null;
+
+            if (nextPlayerId != null) {
+                requestGoldCardSelection(dto.getGameRoomId());
+            } else {
+                globalSession.removeGoldDistributionState(dto.getGameRoomId());
+            }
+
+            SelectGoldCardResponseDto responseDto = new SelectGoldCardResponseDto();
+            responseDto.setSuccess(true);
+            responseDto.setMessage("금덩이 카드 선택 성공");
+            responseDto.setRemainingGoldCardIds(remainingCardIds);
+            responseDto.setNextPlayerUserId(nextPlayerId);
+
+            if (client != null) {
+                client.sendEvent("goldCardSelected", responseDto);
+            }
+            return responseDto;
+        } catch (Exception e) {
+            if (client != null) {
+                client.sendEvent("error", e.getMessage());
+            }
             throw e;
         }
     }

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -319,7 +319,7 @@ public class GameServiceImpl implements GameHandleService {
 
             User currentUser = turnManager.getCurrentTurnUser();
             Map<UUID, Integer> playerCardCounts = new HashMap<>();
-            List<UUID> myCardIds = new ArrayList<>();
+            List<Card> myCards = new ArrayList<>();
             UUID myUserId = currentUser.getId();
 
             for (var userGameRoom : gameRoom.getUserGameRooms()) {
@@ -328,7 +328,7 @@ public class GameServiceImpl implements GameHandleService {
                 playerCardCounts.put(user.getId(), deck != null ? deck.getCards().size() : 0);
                 if (user.getId().equals(myUserId) && deck != null) {
                     for (Card card : deck.getCards()) {
-                        myCardIds.add(card.getId());
+                        myCards.add(card);
                     }
                 }
             }
@@ -341,7 +341,7 @@ public class GameServiceImpl implements GameHandleService {
                             currentUser.getNickname(),
                             playerCardCounts,
                             cardPool.getCards().size(),
-                            myCardIds
+                            myCards
                             // , gameEnded // 필요하다면 DTO에 필드 추가
                             );
             client.sendEvent("gameState", responseDto);

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -124,6 +124,7 @@ public class GameServiceImpl implements GameHandleService {
         GoldDistributionState state = new GoldDistributionState();
         state.minerQueue = new LinkedList<>(orderedMiners);
         state.availableGoldCards = new ArrayList<>(golds);
+        state.distributionMiners = new ArrayList<>(orderedMiners);
         globalSession.setGoldDistributionState(gameRoom.getId(), state);
 
         requestGoldCardSelection(gameRoom.getId());
@@ -132,6 +133,7 @@ public class GameServiceImpl implements GameHandleService {
     private void requestGoldCardSelection(UUID gameRoomId) {
         GoldDistributionState state = globalSession.getGoldDistributionState(gameRoomId);
         if (state == null || state.minerQueue.isEmpty() || state.availableGoldCards.isEmpty()) {
+            broadcastGoldDistributionCompleted(gameRoomId, state);
             globalSession.removeGoldDistributionState(gameRoomId);
             return;
         }
@@ -201,6 +203,24 @@ public class GameServiceImpl implements GameHandleService {
         }
     }
 
+    private void broadcastGoldDistributionCompleted(UUID gameRoomId, GoldDistributionState state) {
+        if (state == null || state.distributionMiners == null) return;
+        List<Map<String, Object>> distributionResults = new ArrayList<>();
+        for (User miner : state.distributionMiners) {
+            for (GoldCard card : miner.getGoldCards()) {
+                Map<String, Object> entry = new HashMap<>();
+                entry.put("userId", miner.getId());
+                entry.put("goldCardId", card.getId());
+                entry.put("amount", card.getAmount());
+                distributionResults.add(entry);
+            }
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("message", "금덩이 분배가 완료되었습니다");
+        result.put("distributionResults", distributionResults);
+
+        socketIoService.sendBroadCast(gameRoomId, "goldDistributionCompleted", result);
+    }
     @Override
     public PlayCardResponseDto playCard(SocketIOClient client, PlayCardRequestDto dto)
             throws Exception {
@@ -423,6 +443,7 @@ public class GameServiceImpl implements GameHandleService {
             if (nextPlayerId != null) {
                 requestGoldCardSelection(dto.getGameRoomId());
             } else {
+                broadcastGoldDistributionCompleted(dto.getGameRoomId(), state);
                 globalSession.removeGoldDistributionState(dto.getGameRoomId());
             }
 

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -145,25 +145,6 @@ public class GameServiceImpl implements GameHandleService {
         scheduleGoldCardAutoSelect(gameRoomId, currentMiner.getId());
     }
 
-    public void handleGoldCardSelection(UUID gameRoomId, UUID userId, UUID selectedGoldCardId) {
-        GoldDistributionState state = globalSession.getGoldDistributionState(gameRoomId);
-        if (state == null) return;
-        User currentMiner = state.minerQueue.peek();
-        if (currentMiner == null || !currentMiner.getId().equals(userId)) return;
-
-        GoldCard selectedCard =
-                state.availableGoldCards.stream()
-                        .filter(card -> card.getId().equals(selectedGoldCardId))
-                        .findFirst()
-                        .orElse(null);
-        if (selectedCard == null) return;
-
-        currentMiner.addGoldCard(selectedCard);
-        state.availableGoldCards.remove(selectedCard);
-        state.minerQueue.poll();
-        requestGoldCardSelection(gameRoomId);
-    }
-
     private void scheduleGoldCardAutoSelect(UUID gameRoomId, UUID userId) {
         new Thread(
                         () -> {
@@ -176,7 +157,11 @@ public class GameServiceImpl implements GameHandleService {
                                 if (currentMiner == null || !currentMiner.getId().equals(userId))
                                     return;
                                 GoldCard autoSelected = state.availableGoldCards.get(0);
-                                handleGoldCardSelection(gameRoomId, userId, autoSelected.getId());
+                                // 자동 선택용 autoDto 실제 값은 NULL
+                                SelectGoldCardRequestDto autoDto = new SelectGoldCardRequestDto();
+                                autoDto.setGameRoomId(gameRoomId);
+                                autoDto.setUserId(userId);
+                                autoDto.setSelectedGoldCardId(autoSelected.getId());
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                             }
@@ -221,6 +206,7 @@ public class GameServiceImpl implements GameHandleService {
 
         socketIoService.sendBroadCast(gameRoomId, "goldDistributionCompleted", result);
     }
+
     @Override
     public PlayCardResponseDto playCard(SocketIOClient client, PlayCardRequestDto dto)
             throws Exception {

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
@@ -1,0 +1,11 @@
+package com.goldstone.saboteur_backend.service.game;
+
+import com.goldstone.saboteur_backend.domain.card.GoldCard;
+import com.goldstone.saboteur_backend.domain.user.User;
+import java.util.List;
+import java.util.Queue;
+
+public class GoldDistributionState {
+    public Queue<User> minerQueue;
+    public List<GoldCard> availableGoldCards;
+}

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
@@ -2,7 +2,6 @@ package com.goldstone.saboteur_backend.service.game;
 
 import com.goldstone.saboteur_backend.domain.card.GoldCard;
 import com.goldstone.saboteur_backend.domain.user.User;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GoldDistributionState.java
@@ -2,10 +2,13 @@ package com.goldstone.saboteur_backend.service.game;
 
 import com.goldstone.saboteur_backend.domain.card.GoldCard;
 import com.goldstone.saboteur_backend.domain.user.User;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 
 public class GoldDistributionState {
     public Queue<User> minerQueue;
     public List<GoldCard> availableGoldCards;
+    public ArrayList<User> distributionMiners;
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -134,9 +134,6 @@ public class GameRoomServiceImpl implements GameRoomService {
                 cardList.add(card);
             }
 
-            System.out.println(cardDeck);
-            System.out.println(user.getCardDeck());
-
             socketIoService.sendEventToUser(user.getId(), "yourCardDeck", cardList);
         }
     }

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -96,6 +96,8 @@ public class GameRoomServiceImpl implements GameRoomService {
         globalSession.removeGameBoardSession(gameRoomId);
         globalSession.removeTurnManagerSession(gameRoomId);
         globalSession.removeGameCardPoolSession(gameRoomId);
+        globalSession.removeGoldFinder(gameRoomId);
+        globalSession.removeGoldDistributionState(gameRoomId);
 
         // 2. 역할 분배
         GameRoleAssignment roleAssigner = new GameRoleAssignment();

--- a/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/gameRoom/GameRoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.goldstone.saboteur_backend.service.gameRoom;
 
 import com.corundumstudio.socketio.SocketIOClient;
 import com.goldstone.saboteur_backend.domain.board.Board;
+import com.goldstone.saboteur_backend.domain.card.Card;
 import com.goldstone.saboteur_backend.domain.game.*;
 import com.goldstone.saboteur_backend.domain.mapping.UserGameRole;
 import com.goldstone.saboteur_backend.domain.user.User;
@@ -14,6 +15,7 @@ import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.UserErrorCode;
 import com.goldstone.saboteur_backend.session.GlobalSession;
 import com.goldstone.saboteur_backend.socketIo.SocketIoService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -68,6 +70,7 @@ public class GameRoomServiceImpl implements GameRoomService {
 
         gameRoom.addPlayer(user);
         client.joinRoom(gameRoom.getId().toString());
+        this.globalSession.addUserSocketId(user.getId(), client.getSessionId());
 
         return gameRoom;
     }
@@ -123,7 +126,18 @@ public class GameRoomServiceImpl implements GameRoomService {
                 newCardPool.assignCardsToUserDecks(gameRoom.getUserGameRooms(), cardPerPlayer);
 
         for (User user : userCardDecks.keySet()) {
+            UserCardDeck cardDeck = userCardDecks.get(user);
             user.setCardDeck(userCardDecks.get(user));
+
+            List<Card> cardList = new ArrayList<>();
+            for (Card card : cardDeck.getCards()) {
+                cardList.add(card);
+            }
+
+            System.out.println(cardDeck);
+            System.out.println(user.getCardDeck());
+
+            socketIoService.sendEventToUser(user.getId(), "yourCardDeck", cardList);
         }
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
+++ b/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
@@ -9,6 +9,7 @@ import com.goldstone.saboteur_backend.domain.mapping.UserGameRole;
 import com.goldstone.saboteur_backend.domain.user.User;
 import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.CommonErrorCode;
+import com.goldstone.saboteur_backend.service.game.GoldDistributionState;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,9 +33,13 @@ public class GlobalSession {
     private final Map<UUID, GoldCardDeck> goldDeckSession = new ConcurrentHashMap<>();
     // Key: Game Room ID
     private final Map<UUID, List<UserGameRole>> roleAssignmentSession = new ConcurrentHashMap<>();
-
-    // userId → socketId 매핑
+    // Key: Game Room ID, userId → socketId 매핑
     private final Map<UUID, UUID> userSocketIdMap = new ConcurrentHashMap<>();
+    // Key: Game Room ID
+    private final Map<UUID, User> goldFinderSession = new ConcurrentHashMap<>();
+    // Key: Game Room ID
+    private final Map<UUID, GoldDistributionState> goldDistributionSession =
+            new ConcurrentHashMap<>();
 
     private <T> T wrapperCall(Supplier<T> action) {
         try {
@@ -129,5 +134,29 @@ public class GlobalSession {
 
     public void removeUserSocketId(UUID userId) {
         userSocketIdMap.remove(userId);
+    }
+
+    public void setGoldFinder(UUID gameRoomId, User user) {
+        wrapperCall(() -> goldFinderSession.put(gameRoomId, user));
+    }
+
+    public User getGoldFinder(UUID gameRoomId) {
+        return wrapperCall(() -> goldFinderSession.get(gameRoomId));
+    }
+
+    public void removeGoldFinder(UUID gameRoomId) {
+        wrapperCall(() -> goldFinderSession.remove(gameRoomId));
+    }
+
+    public void setGoldDistributionState(UUID gameRoomId, GoldDistributionState state) {
+        wrapperCall(() -> goldDistributionSession.put(gameRoomId, state));
+    }
+
+    public GoldDistributionState getGoldDistributionState(UUID gameRoomId) {
+        return wrapperCall(() -> goldDistributionSession.get(gameRoomId));
+    }
+
+    public void removeGoldDistributionState(UUID gameRoomId) {
+        wrapperCall(() -> goldDistributionSession.remove(gameRoomId));
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameServiceEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameServiceEventRegister.java
@@ -1,10 +1,7 @@
 package com.goldstone.saboteur_backend.socketIo.eventRegister;
 
 import com.corundumstudio.socketio.SocketIOServer;
-import com.goldstone.saboteur_backend.dtos.game.request.DiscardCardRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.GetGameStateRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.NextTurnRequestDto;
-import com.goldstone.saboteur_backend.dtos.game.request.PlayCardRequestDto;
+import com.goldstone.saboteur_backend.dtos.game.request.*;
 import com.goldstone.saboteur_backend.service.game.GameHandleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -35,5 +32,10 @@ public class GameServiceEventRegister implements SocketEventRegister {
                 "discardCard",
                 DiscardCardRequestDto.class,
                 (client, data, ackSender) -> this.gameHandleService.discardCard(client, data));
+
+        server.addEventListener(
+                "selectGoldCard",
+                SelectGoldCardRequestDto.class,
+                (client, data, ackSender) -> this.gameHandleService.selectGoldCard(client, data));
     }
 }

--- a/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
@@ -153,8 +153,7 @@ public class GameServiceTest {
             assertEquals(
                     miner.getGoldCards().get(0).getAmount().intValue(),
                     miner.getGoldScore(),
-                    "goldScore가 금덩이 카드의 amount와 같아야 함"
-            );
+                    "goldScore가 금덩이 카드의 amount와 같아야 함");
         }
         // 사보타지는 금덩이 없음
         for (UserGameRole role : roles) {
@@ -165,7 +164,6 @@ public class GameServiceTest {
         }
     }
 
-
     @Test
     @DisplayName("사보타지 승리 시 공식룰 기반 점수 분배")
     void testSaboteurVictoryGoldDistributionOfficialRule() {
@@ -175,12 +173,13 @@ public class GameServiceTest {
             if (role.getRole() == GameRole.SABOTEUR) saboteurs.add(role.getUser());
         }
         int saboteurCount = saboteurs.size();
-        int goldPerSaboteur = switch (saboteurCount) {
-            case 1 -> 4;
-            case 2, 3 -> 3;
-            case 4 -> 2;
-            default -> 0;
-        };
+        int goldPerSaboteur =
+                switch (saboteurCount) {
+                    case 1 -> 4;
+                    case 2, 3 -> 3;
+                    case 4 -> 2;
+                    default -> 0;
+                };
         // 1. 점수 분배
         for (User saboteur : saboteurs) {
             saboteur.setGoldScore(saboteur.getGoldScore() + goldPerSaboteur);
@@ -196,7 +195,6 @@ public class GameServiceTest {
             }
         }
     }
-
 
     @Test
     @DisplayName("카드 소진 시 사보타지 승리 조건 확인")

--- a/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
+++ b/src/test/java/com/goldstone/saboteur_backend/service/game/GameServiceTest.java
@@ -117,85 +117,86 @@ public class GameServiceTest {
     }
 
     @Test
-    @DisplayName("광부 승리 시 금덩이 분배 및 점수 누적")
-    void testMinerVictoryGoldDistribution() {
-        GoldCardDeck goldDeck = globalSession.getGoldDeckSession(gameRoom.getId());
+    @DisplayName("광부 승리 시 공식룰 기반 금덩이 분배 및 점수 누적")
+    void testMinerVictoryGoldDistributionOfficialRule() {
+        // 1. 광부/사보타지 역할 세팅
         List<UserGameRole> roles = globalSession.getRoleAssignment(gameRoom.getId());
-
-        // 광부 인원수만큼 금덩이 카드 분배
         List<User> miners = new ArrayList<>();
+        User goldFinder = users.get(0); // 첫 번째 유저를 금 발견자로 가정
         for (UserGameRole role : roles) {
-            if (role.getRole() == GameRole.MINER) {
-                miners.add(role.getUser());
-            }
+            if (role.getRole() == GameRole.MINER) miners.add(role.getUser());
         }
+        globalSession.setGoldFinder(gameRoom.getId(), goldFinder);
+
+        // 2. 금덩이 덱 준비
+        GoldCardDeck goldDeck = globalSession.getGoldDeckSession(gameRoom.getId());
         List<GoldCard> golds = goldDeck.drawGoldCards(miners.size());
-        for (int i = 0; i < miners.size() && i < golds.size(); i++) {
-            miners.get(i).addGoldCard(golds.get(i));
+
+        // 3. 분배 순서: goldFinder → 나머지 광부
+        List<User> orderedMiners = new ArrayList<>();
+        orderedMiners.add(goldFinder);
+        for (User miner : miners) {
+            if (!miner.equals(goldFinder)) orderedMiners.add(miner);
         }
 
-        // 각 광부의 goldScore가 올바르게 누적되었는지 확인
-        for (User miner : miners) {
+        // 4. 분배 큐로 한 명씩 원하는 카드 선택(여기선 순서대로 선택)
+        for (int i = 0; i < orderedMiners.size(); i++) {
+            User miner = orderedMiners.get(i);
+            GoldCard selected = golds.get(i);
+            miner.addGoldCard(selected); // 실제 서비스는 selectGoldCard 이벤트로 처리
+        }
+
+        // 5. 검증: 각 광부의 goldScore가 받은 카드의 amount와 일치
+        for (int i = 0; i < miners.size(); i++) {
+            User miner = miners.get(i);
             assertEquals(1, miner.getGoldCards().size(), "광부는 1장의 금덩이 카드를 받아야 함");
             assertEquals(
                     miner.getGoldCards().get(0).getAmount().intValue(),
                     miner.getGoldScore(),
-                    "goldScore가 금덩이 카드의 amount와 같아야 함");
+                    "goldScore가 금덩이 카드의 amount와 같아야 함"
+            );
         }
-
-        // 사보타지는 금덩이를 받지 않아야 함
+        // 사보타지는 금덩이 없음
         for (UserGameRole role : roles) {
             if (role.getRole() == GameRole.SABOTEUR) {
-                assertEquals(
-                        0, role.getUser().getGoldCards().size(), "사보타지는 광부 승리 시 금덩이를 받지 않아야 함");
-                assertEquals(0, role.getUser().getGoldScore(), "사보타지의 goldScore는 0이어야 함");
+                assertEquals(0, role.getUser().getGoldCards().size());
+                assertEquals(0, role.getUser().getGoldScore());
             }
         }
     }
+
 
     @Test
-    @DisplayName("사보타지 승리 시 금덩이 분배 및 점수 누적")
-    void testSaboteurVictoryGoldDistribution() {
-        GoldCardDeck goldDeck = globalSession.getGoldDeckSession(gameRoom.getId());
+    @DisplayName("사보타지 승리 시 공식룰 기반 점수 분배")
+    void testSaboteurVictoryGoldDistributionOfficialRule() {
         List<UserGameRole> roles = globalSession.getRoleAssignment(gameRoom.getId());
-
-        // 사보타지 승리 시: 사보타지 수에 관계없이 3장 분배 (사보타지 공식 룰)
         List<User> saboteurs = new ArrayList<>();
         for (UserGameRole role : roles) {
-            if (role.getRole() == GameRole.SABOTEUR) {
-                saboteurs.add(role.getUser());
-            }
+            if (role.getRole() == GameRole.SABOTEUR) saboteurs.add(role.getUser());
         }
-
-        // 사보타지 승리 시 3장 뽑아서 사보타지들이 나눠가짐
-        int goldCardsToDistribute = 3;
-        List<GoldCard> golds = goldDeck.drawGoldCards(goldCardsToDistribute);
-
-        // 사보타지 인원수만큼 순차적으로 분배
-        for (int i = 0; i < golds.size(); i++) {
-            User saboteur = saboteurs.get(i % saboteurs.size());
-            saboteur.addGoldCard(golds.get(i));
-        }
-
-        // 사보타지가 금덩이를 받았는지 확인
-        int totalSaboteurGoldCards = 0;
-        int totalSaboteurScore = 0;
+        int saboteurCount = saboteurs.size();
+        int goldPerSaboteur = switch (saboteurCount) {
+            case 1 -> 4;
+            case 2, 3 -> 3;
+            case 4 -> 2;
+            default -> 0;
+        };
+        // 1. 점수 분배
         for (User saboteur : saboteurs) {
-            totalSaboteurGoldCards += saboteur.getGoldCards().size();
-            totalSaboteurScore += saboteur.getGoldScore();
+            saboteur.setGoldScore(saboteur.getGoldScore() + goldPerSaboteur);
         }
-        assertEquals(3, totalSaboteurGoldCards, "사보타지 승리 시 총 3장의 금덩이 카드가 분배되어야 함");
-        assertTrue(totalSaboteurScore > 0, "사보타지의 총 goldScore가 0보다 커야 함");
-
-        // 광부는 금덩이를 받지 않아야 함
+        // 2. 검증
+        for (User saboteur : saboteurs) {
+            assertEquals(goldPerSaboteur, saboteur.getGoldScore(), "사보타지의 goldScore가 공식룰과 같아야 함");
+        }
+        // 광부는 점수 없음
         for (UserGameRole role : roles) {
             if (role.getRole() == GameRole.MINER) {
-                assertEquals(
-                        0, role.getUser().getGoldCards().size(), "광부는 사보타지 승리 시 금덩이를 받지 않아야 함");
-                assertEquals(0, role.getUser().getGoldScore(), "광부의 goldScore는 0이어야 함");
+                assertEquals(0, role.getUser().getGoldScore());
             }
         }
     }
+
 
     @Test
     @DisplayName("카드 소진 시 사보타지 승리 조건 확인")


### PR DESCRIPTION
말씀드린 대로 금덩이 분배 로직을 구현해봤습니다.

우선 금덩이를 첫번째로 분배받을 사람은 곧 길 카드를 사용했을때 금 목적지와 연결된 사람이므로 **PathCardService**의 **use** 함수에 
``` java
List<Cell> reachableGoals = boardService.getReachableGoals(board);
        if (!reachableGoals.isEmpty()) {
            globalSession.setGoldFinder(request.getRoomId(), user);
        }
```
코드를 추가해 만약 길카드 사용 후 금 목적지에 연결되었다면 **goldfinder**(금 발견자)로 지정해주었습니다.

또한 게임에서 턴을 넘기기 위해 구현한 **nextTurn**으로 금덩이 분배를 받을 턴을 조정하면 문제가 생길수도 있을 거라 생각하여 **GameTurnManger**에서 금덩이 분배를 위한 턴 관리 함수를 새로 만들었습니다.

주요 함수들을 설명하기 전에 가장 중요한 **selectGoldCard**에 대해 작성하겠습니다.

---
각 플레이어들이 금덩이 카드를 선택하는 이벤트 로직을 구현하기 위해
**selectGoldCard** 함수를 만들어주었습니다. 그에 따라 **DTO**를 추가로 구현하고 **GameHandleService**, **GameServiceEventRegister**에도 관련 코드가 추가되었습니다.

해당 함수는 이벤트로서 playCard나 nextTurn처럼 사용되며
다음과 같이 3명의 광부가 게임에서 승리한 시나리오라고 가정했을 시

- 1. 게임 종료: 어떤 광부가 금 목적지에 길카드를 연결

- 2. 분배 시작: 금 발견자부터 순서대로 3장의 금덩이 카드 중 선택

- 3. 첫 번째 광부(금 발견자): 서버로부터 선택 요청 받음

- 4. 카드 선택: 3장 중 원하는 카드 선택하여 서버에 전송

- 5. 두 번째 광부: 남은 2장 중 선택

- 6. 세 번째 광부: 마지막 1장 선택

- 7. 분배 완료: 모든 광부가 금덩이 획득, goldScore 자동 누적(점수가 누적되는 시점은 선택 완료 후로 예상됨)

### **`의도한 요청/응답 메시지 예제:`**

선택 요청 (서버 → 클라이언트)
이벤트: "selectGoldCard"
``` json
{
  "availableGoldCards": [
    {
      "id": "gold-card-001",
      "amount": 1,
      "description": "금덩이 1개"
    },
    {
      "id": "gold-card-002", 
      "amount": 2,
      "description": "금덩이 2개"
    },
    {
      "id": "gold-card-003",
      "amount": 3,
      "description": "금덩이 3개"
    }
  ]
}
```

선택 응답 (클라이언트 → 서버)
이벤트: "selectGoldCard"
```json
{
  "gameRoomId": "room-12345",
  "userId": "user-67890", 
  "selectedGoldCardId": "gold-card-003"
}
```

선택 완료 (서버 → 클라이언트)
이벤트: "goldCardSelected"

```json
{
  "success": true,
  "message": "금덩이 카드 선택 성공",
  "remainingGoldCardIds": ["gold-card-001", "gold-card-002"],
  "nextPlayerUserId": "user-11111"
}
```

분배 완료 (서버 → 전체)
이벤트: "goldDistributionCompleted"

```json
{
  "message": "금덩이 분배가 완료되었습니다",
  "distributionResults": [
    {
      "userId": "user-67890",
      "goldCardId": "gold-card-003", 
      "amount": 3
    },
    {
      "userId": "user-11111",
      "goldCardId": "gold-card-002",
      "amount": 2  
    }
  ]
}
```
---
### **`broadcastGameEnded`**
- broadcastGameEnded 함수의 마지막 부분을 수정하여 승리한 역할에 따라 distributeGoldToMiners 혹은 distributeGoldToSaboteurs 를 호출하도록 만들었습니다.

---
### **`distributeGoldToSaboteurs`**
- distributeGoldToSaboteurs 함수는 사보타지가 승리 시 사보타지에게 금덩이를 분배합니다. 해당 분배 과정은 플레이어가 선택을 진행할 필요 없이 공식룰에 따라 점수(goldscore)를 누적합니다. 
인원수에 따라 개인당 점수가 결정됩니다.(1명:4점, 2-3명:3점, 4명:2점)
공식 룰 상에서는 해당 과정도 금덩이 카드를 점수에 맞게 가져가는 걸로 알고있는데 일단은 이렇게 구현했습니다.

---
### **`distributeGoldToMinsers`**
- distributeGoldToMiners 함수는 광부가 승리 시 광부에게 금덩이를 분배하기 위한 함수입니다. 해당 함수의 과정은 먼저 금 목적지를 연결한 광부를 조회하고(goldfinder) 해당 광부부터 순서를 정합니다. 그 후 광부의 수만큼 무작위로 금덩이 카드덱에서 금덩이 카드를 뽑은 후 첫 번째 광부에게 선택을 요청하게됩니다.(requestGoldCardSelection 함수 호출)

---
### **`requestGoldCardSelection`**
- requestGoldCardSelection 함수는 순서에 따라 각 광부에게 금덩이 카드를  선택하도록 요청합니다. 해당 함수는 큐와 남은 카드가 있는지 검증 하고 큐에서 다음 선택할 광부를 조회합니다. 해당 광부에게 selectGoldCard 이벤트로 카드 목록을 전송해주고, 10초 타임아웃을 적용합니다.

---
### **`scheduleGoldCardAutoSelect`**
- scheduleGoldCardAutoSelect 함수는 requestGoldCardSelection 함수에서 언급된 10초 스케줄링 함수로 만약 10초 이내로 고르지 않는다면 남은 카드 중 첫 번째 카드를 자동으로 선택하게 됩니다. 해당 스케줄링 함수는 내부적으로 시간을 늘려도 좋고 삭제해도 괜찮을 것 같습니다.(프로토타입이므로)

---

@jiho5993 @jooho172200 추가로 제가 의도한 대로 기능들이 잘 작동하는지 프론트 환경에서 테스트해주시면 감사드리겠습니다.