### PR TITLE
Feature/global session 에러 고도화

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
+++ b/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
@@ -45,7 +45,12 @@ public class GlobalSession {
         try {
             return action.get();
         } catch (Exception e) {
-            System.err.println("Exception in GlobalSession wrapperCall:\n" + e);
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            String callerInfo = stackTrace.length > 2 ? stackTrace[2].toString() : "Unknown";
+
+            System.err.println("Exception in GlobalSession wrapperCall from:\n" + callerInfo);
+            e.printStackTrace();
+
             throw new BusinessException(CommonErrorCode.FAILED_TO_MANIPULATE_GLOBAL_SESSION);
         }
     }

--- a/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
+++ b/src/main/java/com/goldstone/saboteur_backend/session/GlobalSession.java
@@ -129,39 +129,45 @@ public class GlobalSession {
         return wrapperCall(() -> roleAssignmentSession.get(gameRoomId));
     }
 
-    public void addUserSocketId(UUID userId, UUID socketId) {
-        userSocketIdMap.put(userId, socketId);
+    public boolean addUserSocketId(UUID userId, UUID socketId) {
+        this.wrapperCall(() -> userSocketIdMap.put(userId, socketId));
+        return true;
     }
 
     public UUID getSocketIdByUserId(UUID userId) {
-        return userSocketIdMap.get(userId);
+        return this.wrapperCall(() -> userSocketIdMap.get(userId));
     }
 
-    public void removeUserSocketId(UUID userId) {
-        userSocketIdMap.remove(userId);
+    public boolean removeUserSocketId(UUID userId) {
+        this.wrapperCall(() -> userSocketIdMap.remove(userId));
+        return true;
     }
 
-    public void setGoldFinder(UUID gameRoomId, User user) {
-        wrapperCall(() -> goldFinderSession.put(gameRoomId, user));
+    public boolean setGoldFinder(UUID gameRoomId, User user) {
+        this.wrapperCall(() -> goldFinderSession.put(gameRoomId, user));
+        return true;
     }
 
     public User getGoldFinder(UUID gameRoomId) {
-        return wrapperCall(() -> goldFinderSession.get(gameRoomId));
+        return this.wrapperCall(() -> goldFinderSession.get(gameRoomId));
     }
 
-    public void removeGoldFinder(UUID gameRoomId) {
-        wrapperCall(() -> goldFinderSession.remove(gameRoomId));
+    public boolean removeGoldFinder(UUID gameRoomId) {
+        this.wrapperCall(() -> goldFinderSession.remove(gameRoomId));
+        return true;
     }
 
-    public void setGoldDistributionState(UUID gameRoomId, GoldDistributionState state) {
-        wrapperCall(() -> goldDistributionSession.put(gameRoomId, state));
+    public boolean setGoldDistributionState(UUID gameRoomId, GoldDistributionState state) {
+        this.wrapperCall(() -> goldDistributionSession.put(gameRoomId, state));
+        return true;
     }
 
     public GoldDistributionState getGoldDistributionState(UUID gameRoomId) {
-        return wrapperCall(() -> goldDistributionSession.get(gameRoomId));
+        return this.wrapperCall(() -> goldDistributionSession.get(gameRoomId));
     }
 
-    public void removeGoldDistributionState(UUID gameRoomId) {
-        wrapperCall(() -> goldDistributionSession.remove(gameRoomId));
+    public boolean removeGoldDistributionState(UUID gameRoomId) {
+        this.wrapperCall(() -> goldDistributionSession.remove(gameRoomId));
+        return true;
     }
 }


### PR DESCRIPTION
### `wrapperCall` 함수 에러 처리 고도화

stacktrace를 확인할 수 없어, 로그 확인이 어려운 부분을 해소시켰습니다.

---

### `wrapperCall` 쓰고 있지 않던 함수들 사용하도록 적용

일부 함수들은 wrapperCall을 안 쓰고 있길래, 호출할 때 적용하도록 하였습니다.
이것을 쓰는 이유는 통일된 에러 핸들링으로 디버깅에 용이하도록 하기 위함인데, 추후 작업할 일이 있다면 적용부탁드리겠습니다.