### PR TITLE
Feature/yyjd 179 덱 조회 이벤트 분리

### DIFF
--- a/src/main/java/com/goldstone/saboteur_backend/dtos/game/request/GetUserDeckRequestDto.java
+++ b/src/main/java/com/goldstone/saboteur_backend/dtos/game/request/GetUserDeckRequestDto.java
@@ -1,0 +1,14 @@
+package com.goldstone.saboteur_backend.dtos.game.request;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class GetUserDeckRequestDto {
+    private UUID gameRoomId;
+    private UUID userId;
+}

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameHandleService.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameHandleService.java
@@ -1,11 +1,14 @@
 package com.goldstone.saboteur_backend.service.game;
 
 import com.corundumstudio.socketio.SocketIOClient;
+import com.goldstone.saboteur_backend.domain.card.Card;
 import com.goldstone.saboteur_backend.dtos.game.request.*;
 import com.goldstone.saboteur_backend.dtos.game.response.GetGameStateResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.NextTurnResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.PlayCardResponseDto;
 import com.goldstone.saboteur_backend.dtos.game.response.SelectGoldCardResponseDto;
+import java.util.List;
+import java.util.UUID;
 
 public interface GameHandleService {
     PlayCardResponseDto playCard(SocketIOClient client, PlayCardRequestDto dto) throws Exception;
@@ -20,4 +23,6 @@ public interface GameHandleService {
 
     SelectGoldCardResponseDto selectGoldCard(SocketIOClient client, SelectGoldCardRequestDto dto)
             throws Exception;
+
+    List<Card> getUserDeck(UUID gameRoomId, UUID userId);
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -21,6 +21,7 @@ import com.goldstone.saboteur_backend.exception.BusinessException;
 import com.goldstone.saboteur_backend.exception.code.error.GameRoomErrorCode;
 import com.goldstone.saboteur_backend.exception.code.error.UserErrorCode;
 import com.goldstone.saboteur_backend.service.board.BoardService;
+import com.goldstone.saboteur_backend.service.gameRoom.GameRoomService;
 import com.goldstone.saboteur_backend.session.GlobalSession;
 import com.goldstone.saboteur_backend.socketIo.SocketIoService;
 import java.util.*;
@@ -35,6 +36,7 @@ public class GameServiceImpl implements GameHandleService {
     @Autowired private final GlobalSession globalSession;
     @Autowired private final SocketIoService socketIoService;
     @Autowired private final BoardService boardService;
+    @Autowired private final GameRoomService gameRoomService;
 
     /* 게임 종료 조건: 카드풀이 비었고, 모든 플레이어의 손패가 0장일 때만 true
     // 또는 금 목적지 도달 시에도 true
@@ -449,5 +451,18 @@ public class GameServiceImpl implements GameHandleService {
             }
             throw e;
         }
+    }
+
+    @Override
+    public List<Card> getUserDeck(UUID gameRoomId, UUID userId) {
+        GameRoom gameRoom = this.gameRoomService.getGameRoomById(gameRoomId);
+        User user =
+                gameRoom.getPlayers().stream()
+                        .filter((player) -> player.getId().equals(userId))
+                        .findFirst()
+                        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        List<Card> result = user.getCardDeck().getCards().stream().toList();
+        return result;
     }
 }

--- a/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
+++ b/src/main/java/com/goldstone/saboteur_backend/service/game/GameServiceImpl.java
@@ -292,7 +292,7 @@ public class GameServiceImpl implements GameHandleService {
             User nextUser = turnManager.nextTurn();
             NextTurnResponseDto responseDto =
                     new NextTurnResponseDto(nextUser.getId(), nextUser.getNickname(), gameEnded);
-            client.sendEvent("turnChanged", responseDto);
+            this.socketIoService.sendBroadCast(gameRoom.getId(), "turnChanged", responseDto);
             return responseDto;
         } catch (Exception e) {
             client.sendEvent("error", e.getMessage());

--- a/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameServiceEventRegister.java
+++ b/src/main/java/com/goldstone/saboteur_backend/socketIo/eventRegister/GameServiceEventRegister.java
@@ -1,8 +1,13 @@
 package com.goldstone.saboteur_backend.socketIo.eventRegister;
 
 import com.corundumstudio.socketio.SocketIOServer;
+import com.goldstone.saboteur_backend.domain.card.Card;
 import com.goldstone.saboteur_backend.dtos.game.request.*;
+import com.goldstone.saboteur_backend.exception.BusinessException;
+import com.goldstone.saboteur_backend.exception.code.error.ErrorCode;
+import com.goldstone.saboteur_backend.exception.responseDto.ErrorResponse;
 import com.goldstone.saboteur_backend.service.game.GameHandleService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -37,5 +42,24 @@ public class GameServiceEventRegister implements SocketEventRegister {
                 "selectGoldCard",
                 SelectGoldCardRequestDto.class,
                 (client, data, ackSender) -> this.gameHandleService.selectGoldCard(client, data));
+
+        server.addEventListener(
+                "getUserDeck",
+                GetUserDeckRequestDto.class,
+                (client, data, ackSender) -> {
+                    try {
+                        List<Card> result =
+                                this.gameHandleService.getUserDeck(
+                                        data.getGameRoomId(), data.getUserId());
+                        client.sendEvent("yourCardDeck", result);
+                    } catch (Exception e) {
+                        if (e instanceof BusinessException) {
+                            ErrorCode errorCode = ((BusinessException) e).getErrorCode();
+                            client.sendEvent("errorEvent", new ErrorResponse(errorCode));
+                        } else {
+                            client.sendEvent("errorEvent", ErrorResponse.internalServerError());
+                        }
+                    }
+                });
     }
 }


### PR DESCRIPTION
- 유저덱 조회 기능을 분리해야할 것 같아, 브로드캐스트가 아닌 클라이언트에게 단일 응답을 하는 이벤트를 구현하였습니다.
- nextTurn 이벤트의 응답이 클라이언트에게 단일 응답을 하는 상황이라, 모든 클라이언트의 정보가 업데이트 되지 않는 현상이 있었습니다.
여기서, 단일 이벤트 전송을 브로드캐스트로 바꿔 해결하였습니다.